### PR TITLE
docs: drop fvm coupling from README and .vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,7 +65,6 @@
     "rxdart",
     "Schyler",
     "sprintf",
-    "vnsilicon",
     "xcconfig"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,6 +67,5 @@
     "sprintf",
     "vnsilicon",
     "xcconfig"
-  ],
-  "dart.flutterSdkPath": ".fvm/versions/3.41.7"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -23,33 +23,34 @@ app.
 └── makefile                     `make help` lists every task
 ```
 
-Stack: Flutter **3.41.7** (via fvm), Dart **3.11.5**, Kotlin **2.1.0**, AGP
-**8.9.1**, Gradle **8.12**. Codegen: `freezed 3.2.3`, `retrofit_generator
-10.2.3`, `json_serializable ^6.11.1`, `hive_ce_generator ^1.9.3`,
+Stack: Flutter **3.41.7**, Dart **3.11.5**, Kotlin **2.1.0**, AGP **8.9.1**,
+Gradle **8.12**. Codegen: `freezed 3.2.3`, `retrofit_generator 10.2.3`,
+`json_serializable ^6.11.1`, `hive_ce_generator ^1.9.3`,
 `injectable_generator ^2.6.2`.
+
+Pin the Flutter version however you prefer — the `makefile` auto-detects
+[fvm](https://fvm.app) if it's on PATH (using `fvm_pubspec.yaml` to resolve
+the version) and falls back to the system `flutter` otherwise.
 
 ## Quickstart
 
 ```bash
-# 1. Install Flutter 3.41.7 via fvm (uses fvm_pubspec.yaml as the source of truth)
-fvm install 3.41.7 && fvm use 3.41.7
-
-# 2. Seed env + keystore config from the templates
+# 1. Seed env + keystore config from the templates
 cp apps/main/.env.example apps/main/.env
 cp apps/main/android/keystores/keystore.properties.example \
    apps/main/android/keystores/keystore.properties
 # Fill in the placeholder values in both files.
 
-# 3. Pull deps + run code generators across all packages
+# 2. Pull deps + run code generators across all packages
 make pub_get
 make gen_all
 
-# 4. Run on a device / emulator
+# 3. Run on a device / emulator
 cd apps/main
-fvm flutter run --flavor dev -t lib/main_dev.dart --dart-define-from-file=./.env
+flutter run --flavor dev -t lib/main_dev.dart --dart-define-from-file=./.env
 
 # or build an APK:
-fvm flutter build apk --debug --flavor dev -t lib/main_dev.dart \
+flutter build apk --debug --flavor dev -t lib/main_dev.dart \
     --dart-define-from-file=./.env
 ```
 


### PR DESCRIPTION
## Summary
- Removes the fvm install step from the README quickstart; the makefile already auto-detects fvm and falls back to system \`flutter\`/\`dart\`, so the template works either way.
- Drops \`dart.flutterSdkPath\` pointing at \`.fvm/versions/3.41.7\` from \`.vscode/settings.json\` — lets the developer wire up whatever SDK path they want.

## Test plan
- [ ] \`make help\` still lists all tasks
- [ ] \`make pub_get && make gen_all\` works with system \`flutter\` on PATH (no fvm)
- [ ] \`flutter build apk --debug --flavor dev -t apps/main/lib/main_dev.dart --dart-define-from-file=apps/main/.env\` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)