### PR TITLE
docs: add .agents/ skill bundle for AI coding agents

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -1,0 +1,47 @@
+# Skill Index
+
+One-line index of every skill under [`./skills/`](./skills/).
+
+## Core
+
+| Skill | Purpose | When to use |
+|---|---|---|
+| [`module-scaffold`](./skills/module-scaffold/SKILL.md) | Scaffold a feature module | Starting a new screen / feature |
+| [`bloc-pattern`](./skills/bloc-pattern/SKILL.md) | `AppBlocBase` + `_StateData` + `_factories` | Adding or modifying state management |
+| [`extension-action`](./skills/extension-action/SKILL.md) | `*.action.dart` for screen handlers | Splitting handlers out of a bloated screen |
+| [`route-config`](./skills/route-config/SKILL.md) | `IRoute` + `CustomRouter` + coordinator | Wiring navigation |
+| [`theme-usage`](./skills/theme-usage/SKILL.md) | `context.themeColor` + `context.textTheme` | Styling a widget |
+| [`data-layer`](./skills/data-layer/SKILL.md) | Freezed DTO + Retrofit + repo | Talking to an API or local store |
+| [`error-handling`](./skills/error-handling/SKILL.md) | `CoreBlocBase.onError` + `ErrorType` router | Deciding what to do with a thrown error |
+| [`localization`](./skills/localization/SKILL.md) | CSV → ARB → `AppLocalizations` | Adding translations |
+| [`code-generation`](./skills/code-generation/SKILL.md) | `make gen_all` and friends | After editing freezed/retrofit/injectable |
+| [`testing`](./skills/testing/SKILL.md) | bloc_test + mocktail + widget tests | Writing or running tests |
+
+## Review
+
+| Skill | Purpose | When to use |
+|---|---|---|
+| [`data-reviewer`](./skills/data-reviewer/SKILL.md) | Data-layer review checklist | Reviewing a diff under `data/` |
+| [`flutter-reviewer`](./skills/flutter-reviewer/SKILL.md) | UI-layer review checklist | Reviewing a diff under `presentation/` |
+
+## Decision shortcuts
+
+```
+Starting a feature?            → module-scaffold → bloc-pattern → route-config
+Cleaning up a screen?          → extension-action
+Adding a network endpoint?     → data-layer → bloc-pattern
+After editing annotated code?  → code-generation
+Adding user-facing strings?    → localization
+Writing tests?                 → testing
+Reviewing data-layer PR?       → data-reviewer
+Reviewing UI PR?               → flutter-reviewer
+Custom error UX?               → error-handling
+Styling questions?             → theme-usage
+```
+
+## Related
+
+- [`README.md`](./README.md) — overview and skill template
+- [`ONBOARDING.md`](./ONBOARDING.md) — orientation for new collaborators
+- [`TROUBLESHOOTING.md`](./TROUBLESHOOTING.md) — common failure modes
+- [`teams/development-team.yaml`](./teams/development-team.yaml) — agent roles

--- a/.agents/ONBOARDING.md
+++ b/.agents/ONBOARDING.md
@@ -1,0 +1,118 @@
+# Onboarding
+
+Welcome. This template ships project-local skills under `.agents/skills/`
+that AI agents auto-discover. You don't have to do anything to install
+them — clone the repo, open it in your agent of choice, and start
+working.
+
+## Quick start
+
+```bash
+git clone <repo>
+cd <repo>
+cp apps/main/.env.example apps/main/.env
+cp apps/main/android/keystores/keystore.properties.example \
+   apps/main/android/keystores/keystore.properties
+# Fill in placeholder values in both.
+
+make pub_get
+make gen_all
+make lang
+```
+
+Then run the app:
+
+```bash
+cd apps/main
+flutter run --flavor dev -t lib/main_dev.dart \
+  --dart-define-from-file=./.env
+```
+
+## Activating an agent role
+
+Mention an agent name in your message — the team yaml in
+[`teams/development-team.yaml`](./teams/development-team.yaml) declares
+the available roles:
+
+| Agent | Use for |
+|---|---|
+| `@orchestrator` | Plan and delegate complex tasks |
+| `@explorer` | Find files, patterns, code |
+| `@oracle` | Architecture / design review |
+| `@security-auditor` | Spot vulnerabilities |
+| `@researcher` | API / package documentation |
+| `@designer` | UI / UX |
+| `@fixer` | Implement, fix, refactor |
+| `@git-master` | Commits, rebasing, history |
+
+## Letting skills auto-load
+
+Just describe what you want. The agent picks the right skill from
+[`INDEX.md`](./INDEX.md):
+
+```
+"Add a farm-registration feature with a list and detail screen."
+→ agent loads module-scaffold, then bloc-pattern, then route-config
+```
+
+You can also call a skill explicitly:
+
+```
+"Use bloc-pattern to wire up the form submission flow."
+```
+
+## Common workflows
+
+### New feature
+
+1. `module-scaffold` — generate the module via `make run_module_generator`
+2. `bloc-pattern` — author events, `_StateData`, state classes
+3. `route-config` — register the route, expose a coordinator
+4. `theme-usage` — style with `context.themeColor` / `context.textTheme`
+5. `localization` — add strings to `apps/main/lib/l10n/localizations.csv`
+6. `code-generation` — `make gen_all` (and `make lang` if strings changed)
+7. `testing` — bloc + widget tests
+
+### API integration
+
+1. `data-layer` — Freezed DTO + Retrofit client + repository
+2. `code-generation` — `make gen_all`
+3. `bloc-pattern` — wire the repo through a usecase into a bloc
+4. `error-handling` — only if you need behavior beyond the default UI router
+5. `testing` — repository + bloc tests with mocktail
+
+### Bug fix
+
+1. `@explorer` — locate the failing path
+2. `@oracle` — agree on the root cause
+3. `@fixer` — implement the fix
+4. `testing` — pin it with a regression test
+5. `@git-master` — atomic commit
+
+### PR review
+
+- `data-reviewer` for changes under `data/`
+- `flutter-reviewer` for changes under `presentation/`
+
+## Conventions in one screen
+
+- Clean architecture: `presentation/` → `domain/` → `data/`.
+- Bloc: extends `AppBlocBase<E, S>`; abstract state hierarchy with a
+  freezed `_StateData` and a `_factories` map.
+- Screens: `StateBase<T>`, wrapped in `ScreenForm` / `MainPageForm`,
+  always with a `static String routeName` and a `*.action.dart` partner.
+- Routes: `IRoute` returning `List<CustomRouter>`; navigation via a
+  `BuildContext` coordinator extension using `PushBehavior`.
+- Theming: `context.themeColor.*` for colors, Material 3 typography
+  slots plus the `AppTextTheme` extras (`titleTiny`, `inputTitle`, …).
+- Localization: edit `localizations.csv`, run `make lang`. Use
+  `trans.<key>` or `context.l10n.<key>`.
+- Codegen: `make gen_all` after touching `@freezed`, `@RestApi`,
+  `@Injectable`, `@HiveType`, `_StateData`, etc.
+
+## Reference docs
+
+- [`INDEX.md`](./INDEX.md) — skill index
+- [`README.md`](./README.md) — skill system overview
+- [`TROUBLESHOOTING.md`](./TROUBLESHOOTING.md) — when things break
+- Repo-level `README.md` and `makefile` for build/run details

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,84 @@
+# Agent Skills
+
+Project-local skills for AI coding agents working in this Flutter base
+template. Drop the whole `.agents/` directory into a forked app and the
+skills travel with it.
+
+These skills target the standard `.agents/skills/` location used by
+OpenCode, Claude Code, Cursor, GitHub Copilot, Windsurf, and others.
+
+## Quick links
+
+- [`INDEX.md`](./INDEX.md) — one-line summary of every skill
+- [`ONBOARDING.md`](./ONBOARDING.md) — orientation for new collaborators
+- [`TROUBLESHOOTING.md`](./TROUBLESHOOTING.md) — common failure modes
+
+## Skills
+
+| Skill | What it covers |
+|---|---|
+| [`module-scaffold`](./skills/module-scaffold/SKILL.md) | Scaffold a feature module via `make run_module_generator` or by hand |
+| [`bloc-pattern`](./skills/bloc-pattern/SKILL.md) | `AppBlocBase` + abstract state hierarchy + freezed `_StateData` |
+| [`extension-action`](./skills/extension-action/SKILL.md) | `*.action.dart` part-of screen for handlers + bloc listeners |
+| [`route-config`](./skills/route-config/SKILL.md) | `IRoute` / `CustomRouter` (from core) + `BuildContext` coordinator |
+| [`theme-usage`](./skills/theme-usage/SKILL.md) | `context.themeColor` + `context.textTheme` from fl_theme |
+| [`data-layer`](./skills/data-layer/SKILL.md) | Freezed DTO + Retrofit + hive_ce + repository wired through injectable |
+| [`error-handling`](./skills/error-handling/SKILL.md) | Throw → `CoreBlocBase.onError` → `StateBase` `ErrorType` router |
+| [`localization`](./skills/localization/SKILL.md) | CSV → ARB → generated `AppLocalizations` |
+| [`code-generation`](./skills/code-generation/SKILL.md) | `make gen_all` / `make gen_<scope>` / `make lang` |
+| [`testing`](./skills/testing/SKILL.md) | bloc_test + mocktail patterns; `flutter test` / `make coverage_main` |
+| [`data-reviewer`](./skills/data-reviewer/SKILL.md) | Review checklist for data-layer diffs |
+| [`flutter-reviewer`](./skills/flutter-reviewer/SKILL.md) | Review checklist for UI-layer diffs |
+
+## Conventions enforced
+
+These skills assume the structure shipped by the template:
+
+- Clean architecture: `presentation/` → `domain/` → `data/`.
+- BLoC via `flutter_bloc` + `bloc_concurrency`, with the `_StateData`
+  pattern + `_factories` map (not freezed sealed unions).
+- Routing via `IRoute` + `CustomRouter` from `core/lib/presentation/route/`
+  (re-exported via `package:core/core.dart`).
+- Theming via `plugins/fl_theme/` — Material 3 token names plus
+  `AppTextTheme` extras; reach colors with `context.themeColor`.
+- Localization via CSV in `apps/main/lib/l10n/localizations.csv`,
+  generated with `make lang`.
+- Code generation orchestrated through the makefile (`make gen_all`).
+
+## Skill structure
+
+```
+skills/
+└── <name>/
+    └── SKILL.md
+```
+
+Each `SKILL.md` opens with frontmatter:
+
+```yaml
+---
+name: <name>
+description: <one-line summary, ≤1024 chars>
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+---
+```
+
+Followed by sections: **When to use**, the conventions or patterns to
+enforce, references with file paths, and a checklist.
+
+## Adding a new skill
+
+1. `mkdir .agents/skills/<name>` and add `SKILL.md`.
+2. Document the rule, not the symptom — explain when the skill applies
+   and what it enforces.
+3. Cross-reference related skills under a `## Related` heading.
+4. Update [`INDEX.md`](./INDEX.md) with one line for the new skill.
+5. Run a real task through it to validate.
+
+## Team configuration
+
+Agent roles for this template are declared in
+[`teams/development-team.yaml`](./teams/development-team.yaml).

--- a/.agents/TROUBLESHOOTING.md
+++ b/.agents/TROUBLESHOOTING.md
@@ -1,0 +1,199 @@
+# Troubleshooting
+
+Common failure modes when working in this template, with the smallest
+fix that gets you unstuck.
+
+---
+
+## Code generation
+
+### "Could not find part of"
+
+The `part 'foo.freezed.dart';` directive does not match the file name.
+Fix: ensure each source file declares `part '<basename>.freezed.dart';`
+and `part '<basename>.g.dart';` exactly matching its own filename.
+
+### "Missing concrete implementation" (freezed)
+
+You used `class` instead of `sealed class`.
+
+```dart
+// wrong
+@freezed
+class FooModel with _$FooModel { ... }
+
+// right
+@freezed
+sealed class FooModel with _$FooModel { ... }
+```
+
+### "Non-nullable field must have a default value"
+
+Add `@Default(...)`:
+
+```dart
+@Default([]) List<String> roles,
+@Default(false) bool isActive,
+```
+
+### Build cache stale / "Conflicting outputs"
+
+Clean and regenerate the affected scope:
+
+```bash
+fvm dart run build_runner clean   # inside apps/main, core, or modules/data_source
+make gen_all
+```
+
+The makefile already passes `--delete-conflicting-outputs`; only worry
+about this when invoking `dart run build_runner` directly.
+
+---
+
+## Bloc / state
+
+### `Null check operator used on a null value` from `copyWith<T>`
+
+You added a new concrete state class and forgot to register it in
+`_factories` inside `<feature>_state.dart`. Add the matching entry:
+
+```dart
+final _factories = <Type, Function(_StateData data)>{
+  FeatureInitial: (data) => FeatureInitial(data: data),
+  FeatureLoaded:  (data) => FeatureLoaded(data: data),  // ← add this
+};
+```
+
+### Loading spinner never disappears
+
+`_blocListener` in the action file is missing `hideLoading()`, or a
+handler called `showLoading()` (CoreDelegate fan-out) and didn't pair it with `hideLoading()` in `finally`.
+Both fixes apply:
+
+```dart
+void _blocListener(BuildContext context, FeatureState state) {
+  hideLoading();
+  // … other reactions …
+}
+```
+
+### Bloc handler swallows an error
+
+Don't wrap the whole handler in `try { ... } catch (_) {}` — the screen
+won't show a dialog. Either:
+
+1. Let the error propagate (default path; `CoreBlocBase.onError` routes
+   it via `ErrorType`).
+2. Catch only the specific exception you can recover from and rethrow
+   the rest.
+
+See [`error-handling`](./skills/error-handling/SKILL.md).
+
+---
+
+## Navigation
+
+### `BlocProvider.of() called with a context that does not contain a BLoC`
+
+The route builder didn't wrap the screen in `BlocProvider`. Fix the
+route file:
+
+```dart
+CustomRouter<FeatureArgs>(
+  path: FeatureScreen.routeName,
+  builder: (context, uri, extra) => BlocProvider<FeatureBloc>(
+    create: (_) => injector.get(param1: extra),
+    child: FeatureScreen(args: extra),
+  ),
+)
+```
+
+### "Route not found"
+
+`routeName` is missing the leading `/`, has uppercase letters, or the
+route module wasn't spread into the parent `IRoute`. Both must hold.
+
+### Deep link query params don't reach the screen
+
+The route is missing `extraFromUrlQueries: <Args>.fromUrlParams`. The
+`buildExtra` helper in `CustomRouter` only pulls from the URI when that
+hook is provided.
+
+---
+
+## Theming
+
+### Reference to `BrandColor.*` won't compile
+
+`BrandColor` does not exist in this template. Use `context.themeColor.*`
+instead — see [`theme-usage`](./skills/theme-usage/SKILL.md) for the
+mapping.
+
+### `context.textTheme.titleMd` undefined
+
+Tokens like `titleMd` / `bodyXs` / `labelXs` don't exist here. Use the
+Material 3 slot names plus the `AppTextTheme` extras:
+
+```dart
+context.textTheme.titleMedium  // not titleMd
+context.textTheme.bodySmall    // not bodyXs
+context.textTheme.labelLarge   // not labelLg
+context.textTheme.titleTiny    // extra: ~85% of titleSmall
+context.textTheme.inputTitle   // extra
+```
+
+---
+
+## Localization
+
+### Keys don't appear in the UI
+
+You edited `intl_en.arb` or a generated `app_localizations*.dart` file
+directly — those are regenerated on `make lang` and your edits get
+overwritten. Edit `apps/main/lib/l10n/localizations.csv` instead, then
+run `make lang`.
+
+### `{name}` placeholder is rendered literally
+
+Parameters are positional in this generator — use `{0}`, `{1}`, …, then
+call `trans.welcomeMessage('Huy')` with the same number of positional
+arguments.
+
+---
+
+## Git / commit
+
+### Pre-commit hook fails
+
+Run the relevant target before retrying:
+
+```bash
+make format        # dart format
+make gen_all       # if codegen output is stale
+```
+
+### Generated files are diff-noisy
+
+That's expected — generated files **are** committed. Stage them with the
+matching source change in the same commit so reviewers can see them.
+
+---
+
+## Performance
+
+### Janky scroll / rebuilds on every frame
+
+- Use `ListView.builder` (or `Sliver*Builder`) instead of
+  `ListView(children: items.map(...).toList())`.
+- Add `const` to constructors with constant arguments.
+- Pull child widgets out of large `build` methods so they only rebuild
+  when they need to.
+- Wrap independently-animating subtrees in `RepaintBoundary`.
+
+---
+
+## Quick command reference
+
+Run `make help` for the canonical list. The targets you'll most often
+need: `pub_get`, `gen_all`, `lang`, `format`, `coverage_main`,
+`run_module_generator`, `build`.

--- a/.agents/skills/bloc-pattern/SKILL.md
+++ b/.agents/skills/bloc-pattern/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: bloc-pattern
+description: Implements BLoC state management using AppBlocBase, an abstract State hierarchy, and a freezed _StateData
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+  framework: flutter
+  pattern: bloc
+---
+
+# BLoC Pattern Skill
+
+## When to use
+
+- Adding state management to a new module.
+- Modifying events/states for an existing bloc.
+
+## Conventions enforced
+
+This template uses a specific bloc shape that is **not** the typical "freezed sealed union" pattern. The state hierarchy is hand-written `abstract class` siblings sharing a freezed `_StateData`; events are hand-written subclasses of an abstract event. Follow this shape exactly — `state.copyWith<T>()` and the `_factories` map depend on it.
+
+1. Bloc extends `AppBlocBase<E, S>` (defined in `apps/main/lib/presentation/base/bloc_base.dart`, ultimately `CoreBlocBase` from `core/`).
+2. Bloc is annotated `@Injectable()`. Use `@factoryParam` for runtime args.
+3. Event classes inherit from a single abstract `<X>Event` — no freezed union.
+4. State classes inherit from a single abstract `<X>State` and share a freezed `_StateData`. The base provides `copyWith<T extends <X>State>({_StateData? data})` backed by a `_factories` map.
+5. `_StateData` is `@freezed sealed class _StateData with _$StateData` — generator declares it that way; do not change.
+6. Imports: `package:core/core.dart` (re-exports flutter_bloc, AppBlocBase, helpers), `package:freezed_annotation/freezed_annotation.dart`, `package:injectable/injectable.dart`.
+7. Run `make gen_all` after editing — `<feature>_bloc.freezed.dart` is generated.
+
+## Reference: bloc file (`<feature>_bloc.dart`)
+
+```dart
+import 'dart:async';
+
+import 'package:core/core.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../../domain/usecases/<feature>/<feature>_usecase.dart';
+import '../../../base/base.dart';
+
+part '<feature>_bloc.freezed.dart';
+part '<feature>_event.dart';
+part '<feature>_state.dart';
+
+@Injectable()
+class FeatureBloc extends AppBlocBase<FeatureEvent, FeatureState> {
+  final FeatureUsecase _usecase;
+
+  FeatureBloc(
+    @factoryParam Item? initial,
+    this._usecase,
+  ) : super(FeatureInitial(data: _StateData(initial: initial))) {
+    on<GetFeatureEvent>(_onGet);
+  }
+
+  Future<void> _onGet(GetFeatureEvent event, Emitter<FeatureState> emit) async {
+    final detail = await _usecase.getById(event.id);
+    emit(state.copyWith<FeatureInitial>(
+      data: state.data.copyWith(detail: detail),
+    ));
+  }
+}
+```
+
+## Reference: state file (`<feature>_state.dart`)
+
+```dart
+// ignore_for_file: unused_element
+part of '<feature>_bloc.dart';
+
+@freezed
+sealed class _StateData with _$StateData {
+  const factory _StateData({
+    Item? detail,
+    @Default([]) List<Item> items,
+    @Default(false) bool canLoadMore,
+  }) = __StateData;
+}
+
+abstract class FeatureState {
+  final _StateData data;
+
+  FeatureState(this.data);
+
+  T copyWith<T extends FeatureState>({_StateData? data}) {
+    return _factories[T == FeatureState ? runtimeType : T]!(
+      data ?? this.data,
+    );
+  }
+
+  // Forward common reads off _StateData.
+  Item? get detail => data.detail;
+  List<Item> get items => data.items;
+  bool get canLoadMore => data.canLoadMore;
+}
+
+class FeatureInitial extends FeatureState {
+  FeatureInitial({required _StateData data}) : super(data);
+}
+
+class FeatureLoaded extends FeatureState {
+  FeatureLoaded({required _StateData data}) : super(data);
+}
+
+final _factories = <Type, Function(_StateData data)>{
+  FeatureInitial: (data) => FeatureInitial(data: data),
+  FeatureLoaded: (data) => FeatureLoaded(data: data),
+};
+```
+
+Add a new state class? Add it to `_factories` in the same edit — `copyWith<T>()` will throw at runtime otherwise.
+
+## Reference: event file (`<feature>_event.dart`)
+
+```dart
+part of '<feature>_bloc.dart';
+
+abstract class FeatureEvent {}
+
+class GetFeatureEvent extends FeatureEvent {
+  final String id;
+  GetFeatureEvent(this.id);
+}
+
+class LoadMoreEvent extends FeatureEvent {}
+```
+
+For events that need to surface a result back to the caller (e.g. login flows), pass a `Completer<T>` on the event and complete it inside the handler.
+
+## Loading + error handling
+
+`StateBase<T>` (the screen base) wires `delegate?.addLoadingHandler` and `addErrorHandler` against the bloc's `CoreDelegate` mixin during `initState`. So a bloc generally does not call `showLoading`/`hideLoading` itself — the screen does, and `CoreBlocBase.onError` already routes thrown errors through the screen's error UI.
+
+When you do need explicit control inside a handler:
+
+```dart
+Future<void> _onSubmit(SubmitEvent event, Emitter<FeatureState> emit) async {
+  showLoading();   // CoreDelegate fan-out — wakes the screen's EasyLoading
+  try {
+    await _usecase.submit(event.payload);
+    emit(state.copyWith<FeatureSuccess>());
+  } finally {
+    hideLoading();
+  }
+}
+```
+
+`showLoading()` / `hideLoading()` here are the `CoreDelegate` versions
+inherited via `CoreBlocBase`. They notify every registered screen
+(usually one) which then calls its own `showLoading()` / `hideLoading()`
+on `EasyLoading`. There's a deliberate name collision with the screen's
+methods — see `error-handling` for the full picture.
+
+Throw or rethrow on errors — `CoreBlocBase.onError` converts them to `ErrorData` and forwards to the screen.
+
+## Using state in the UI
+
+`BlocBuilder` works against the runtime type:
+
+```dart
+BlocBuilder<FeatureBloc, FeatureState>(
+  builder: (context, state) {
+    if (state is FeatureLoaded) return _buildList(state.items);
+    return _buildEmpty();
+  },
+)
+```
+
+Action files (see `extension-action`) typically use `_blocListener(BuildContext context, FeatureState state)` for side effects and dispatch events via `bloc.add(...)`.
+
+## Checklist
+
+- [ ] Bloc extends `AppBlocBase<E, S>` and is `@Injectable()`.
+- [ ] `<feature>_bloc.dart` declares the three `part` directives (freezed, event, state).
+- [ ] `_StateData` is `@freezed sealed class` and uses `@Default(...)` for non-nullable defaults.
+- [ ] Every concrete state subclass has a matching entry in `_factories`.
+- [ ] Events extend the abstract `<X>Event`; no freezed unions for events or states.
+- [ ] Long-running handlers call `showLoading()` and pair it with `hideLoading()` in a `finally` block (CoreDelegate fan-out).
+- [ ] `make gen_all` run after changes.
+
+## Common mistakes
+
+- Treating `FeatureState` as a freezed union (`FeatureState.loading()`/`.loaded()`) — this template does not.
+- Forgetting to register a new concrete state in `_factories` (causes `Null check operator used on a null value` from `copyWith<T>`).
+- Importing `package:flutter_bloc/flutter_bloc.dart` directly — go through `package:core/core.dart`.
+- Doing both `emit(...error)` and `rethrow` — `CoreBlocBase.onError` already handles thrown errors; emit OR throw, don't double-fire.
+
+## Related
+
+- [`module-scaffold`](../module-scaffold/SKILL.md)
+- [`extension-action`](../extension-action/SKILL.md)
+- [`error-handling`](../error-handling/SKILL.md)
+- [`data-layer`](../data-layer/SKILL.md)

--- a/.agents/skills/code-generation/SKILL.md
+++ b/.agents/skills/code-generation/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: code-generation
+description: Runs build_runner across core, data_source, and apps/main via the makefile after edits to freezed/injectable/retrofit/hive sources
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+  framework: flutter
+  pattern: code-generation
+---
+
+# Code Generation Skill
+
+## When to use
+
+After editing any file annotated with `@freezed`, `@JsonSerializable`/`@JsonKey`, `@Injectable`/`@LazySingleton`/`@Singleton`/`@module`, `@RestApi`, `@HiveType`, or that declares a `_StateData` for a bloc.
+
+## Commands
+
+The makefile is the canonical interface. It auto-detects `fvm` if present and falls back to the system Flutter SDK.
+
+| Command | What it runs |
+|---|---|
+| `make gen_all` | `gen_core` → `gen_data_source` → `gen_main` (full graph) |
+| `make gen_main` | `build_runner build` only inside `apps/main/` |
+| `make gen_core` | `build_runner build` only inside `core/` |
+| `make gen_data_source` | `build_runner build` only inside `modules/data_source/` |
+| `make gen` | Interactive picker for the same targets |
+| `make lang` | Regenerates `app_localizations_*.dart` from `localizations.csv` |
+| `make asset` | Regenerates the asset accessor under each package |
+| `make format` | `dart format .` across the repo |
+| `make pub_get` | `pub get` across plugins, core, main |
+
+When you don't know the scope of your change, run `make gen_all`. It's slower but never wrong.
+
+## Generated files
+
+| Pattern | Producer | Hand-edit? |
+|---|---|---|
+| `*.freezed.dart` | freezed | Never |
+| `*.g.dart` | json_serializable, retrofit, hive_ce | Never |
+| `*.config.dart` | injectable | Never |
+| `app_localizations*.dart` | flutter intl tooling via `make lang` | Never |
+
+All generated files **are** committed to source control — CI does not regenerate them.
+
+## When generation fails
+
+1. **Stale cache** — `dart run build_runner clean` from inside the failing package, then re-run `make gen_<scope>`.
+2. **Missing `part` directive** — every freezed/json/retrofit source needs the matching `part 'foo.freezed.dart';` / `part 'foo.g.dart';`.
+3. **Missing `sealed`** — freezed unions and the bloc `_StateData` require `sealed class`.
+4. **Missing `@Default(...)`** — non-nullable fields without a default break codegen.
+5. **Conflicting outputs** — the makefile already passes `--delete-conflicting-outputs`; if you're invoking `dart run build_runner` directly, do the same.
+
+## Watch mode
+
+Useful while iterating on a single package:
+
+```bash
+cd apps/main
+fvm dart run build_runner watch --delete-conflicting-outputs   # or `dart run …` if no fvm
+```
+
+Stop with Ctrl-C. Don't leave it running in CI.
+
+## CI hook
+
+For a pre-commit/CI gate, run `make gen_all` and then assert that no generated artifacts changed:
+
+```bash
+make gen_all
+git diff --exit-code -- '**/*.freezed.dart' '**/*.g.dart' '**/*.config.dart' \
+  'apps/main/lib/l10n/generated/**'
+```
+
+## Checklist
+
+- [ ] After adding/changing a `@freezed`/`@Injectable`/`@RestApi`/`@HiveType` source, `make gen_all` (or the narrow target) was run.
+- [ ] After editing `localizations.csv`, `make lang` was run.
+- [ ] No hand-edited generated files in the diff.
+- [ ] All generated files are staged for commit.
+
+## Common mistakes
+
+- Running `dart run build_runner build` without `--delete-conflicting-outputs` and stopping at the first conflict.
+- Editing `*.freezed.dart` to silence an analyzer warning — fix the source instead.
+- Forgetting that `make gen_main` does *not* touch `core/` or `modules/data_source/`. When core types change, run `make gen_all`.
+
+## Related
+
+- [`bloc-pattern`](../bloc-pattern/SKILL.md)
+- [`data-layer`](../data-layer/SKILL.md)
+- [`module-scaffold`](../module-scaffold/SKILL.md)

--- a/.agents/skills/data-layer/SKILL.md
+++ b/.agents/skills/data-layer/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: data-layer
+description: Builds the data layer with Freezed DTOs, Retrofit clients, hive_ce local stores, and repositories wired through injectable
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+  framework: flutter
+  pattern: data-layer
+---
+
+# Data Layer Skill
+
+## When to use
+
+- Adding a new model that crosses the network or local store.
+- Wrapping a new REST endpoint group in a Retrofit client.
+- Implementing a repository that mediates between API and bloc.
+
+## Stack
+
+| Concern | Package | Generator output |
+|---|---|---|
+| DTO + value classes | `freezed` + `freezed_annotation` + `json_serializable` | `*.freezed.dart`, `*.g.dart` |
+| REST client | `retrofit` + `dio` + `retrofit_generator` | `*.g.dart` |
+| Local store | `hive_ce` + `hive_ce_generator` | `*.g.dart` |
+| DI | `injectable` + `injectable_generator` | `*.config.dart` |
+
+The shared module `modules/data_source/` exposes Retrofit + hive_ce plumbing; per-feature clients live there or, for app-specific endpoints, under `apps/main/lib/data/data_source/`. Models that are shared across apps go in `core/lib/data/models/`.
+
+Run `make gen_all` after edits.
+
+## Freezed DTO
+
+```dart
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user_model.freezed.dart';
+part 'user_model.g.dart';
+
+@freezed
+sealed class UserModel with _$UserModel {
+  const factory UserModel({
+    required String id,
+    required String name,
+    @JsonKey(name: 'display_name') String? displayName,
+    @Default(false) bool isActive,
+    @Default([]) List<String> roles,
+    @JsonKey(name: 'updated_at') DateTime? updatedAt,
+  }) = _UserModel;
+
+  factory UserModel.fromJson(Map<String, dynamic> json) =>
+      _$UserModelFromJson(json);
+}
+```
+
+Rules:
+- DTOs are `sealed class` with `@freezed`.
+- All non-nullable collections use `@Default([])` / `@Default({})`.
+- Use `@JsonKey(name: ...)` for any field whose JSON key is not exact-match camelCase.
+- Wrap `DateTime` only when the API doesn't emit ISO-8601; otherwise the default converter works.
+
+## Enum serialization
+
+```dart
+enum OrderStatus {
+  @JsonValue('pending')   pending,
+  @JsonValue('shipped')   shipped,
+  @JsonValue('delivered') delivered,
+}
+```
+
+Always pin the wire string with `@JsonValue` — never rely on Dart's enum name matching.
+
+## Retrofit client
+
+```dart
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/user_model.dart';
+
+part 'user_api_client.g.dart';
+
+@RestApi()
+abstract class UserApiClient {
+  factory UserApiClient(Dio dio, {String? baseUrl}) = _UserApiClient;
+
+  @GET('/api/v1/users/{id}')
+  Future<UserModel> getUser(@Path('id') String id);
+
+  @GET('/api/v1/users')
+  Future<List<UserModel>> getUsers({
+    @Query('page') int? page,
+    @Query('limit') int? limit,
+  });
+
+  @POST('/api/v1/users')
+  Future<UserModel> createUser(@Body() UserModel user);
+
+  @PUT('/api/v1/users/{id}')
+  Future<UserModel> updateUser(@Path('id') String id, @Body() UserModel user);
+
+  @DELETE('/api/v1/users/{id}')
+  Future<void> deleteUser(@Path('id') String id);
+}
+```
+
+Base URL flows from app config (`apps/main/lib/envs.dart` + `--dart-define-from-file`), not from the client.
+
+Multipart uploads:
+
+```dart
+@Multipart
+@POST('/api/v1/upload')
+Future<UploadResponse> upload(
+  @Part() String type,
+  @PartFile() MultipartFile file,
+);
+```
+
+## Hive local store
+
+For simple key/value caches use a hive_ce-backed data source. Generated boxes live under `data_source/local/` and surface a single class consumed by the repository.
+
+```dart
+@HiveType(typeId: 7)
+class UserHive extends HiveObject {
+  UserHive({required this.id, required this.name});
+
+  @HiveField(0) final String id;
+  @HiveField(1) final String name;
+}
+```
+
+Don't reuse a `typeId` — pick a unique one across the app.
+
+## Repository
+
+Repositories accept the API client (and optionally a local data source) by constructor and decide cache/refresh policy. They are the only layer feature blocs depend on.
+
+```dart
+import 'package:injectable/injectable.dart';
+
+import '../api/user_api_client.dart';
+import '../models/user_model.dart';
+
+@LazySingleton(as: UserRepository)
+class UserRepositoryImpl implements UserRepository {
+  UserRepositoryImpl(this._api);
+
+  final UserApiClient _api;
+
+  @override
+  Future<UserModel> getUser(String id) => _api.getUser(id);
+
+  @override
+  Future<List<UserModel>> getUsers({int page = 1, int limit = 20}) =>
+      _api.getUsers(page: page, limit: limit);
+}
+```
+
+Errors surface as `DioException` and are translated by the screen-level error handler (see `error-handling`). Don't wrap them at the repository layer unless you need a domain-specific failure type.
+
+## DI
+
+The `injectable` graph picks up `@Injectable`/`@LazySingleton`/`@Singleton` automatically once `make gen_all` is run. For Retrofit clients, register a `@module` somewhere under `apps/main/lib/di/`:
+
+```dart
+@module
+abstract class ApiModule {
+  @lazySingleton
+  UserApiClient userApiClient(Dio dio) => UserApiClient(dio);
+}
+```
+
+## Checklist
+
+- [ ] DTO is `sealed class` with `@freezed`, defaults provided for collections.
+- [ ] `@JsonKey` set for every non-camelCase JSON field.
+- [ ] Enum factories use `@JsonValue`.
+- [ ] Retrofit client uses `@RestApi`, `@Path`, `@Query`, `@Body` correctly; no hardcoded base URL.
+- [ ] Repository depends on the API client (and any local store), exposes a domain-friendly API.
+- [ ] Repository registered through `@LazySingleton` (or DI module).
+- [ ] `make gen_all` run; generated files staged.
+
+## Common mistakes
+
+- Mutable lists/maps in DTOs (drop the default and end up with nullables).
+- Repositories making `Dio` calls directly, bypassing Retrofit.
+- Forgetting `part 'foo.g.dart';` — Retrofit won't compile.
+- Reusing `@HiveType(typeId: …)` across types.
+
+## Related
+
+- [`bloc-pattern`](../bloc-pattern/SKILL.md)
+- [`error-handling`](../error-handling/SKILL.md)
+- [`code-generation`](../code-generation/SKILL.md)
+- [`data-reviewer`](../data-reviewer/SKILL.md)

--- a/.agents/skills/data-reviewer/SKILL.md
+++ b/.agents/skills/data-reviewer/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: data-reviewer
+description: Reviews data-layer changes — Freezed DTOs, Retrofit clients, hive_ce stores, and repositories — against the template's conventions
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+  framework: flutter
+  pattern: code-review
+---
+
+# Data Layer Reviewer Skill
+
+## When to use
+
+- A diff touches files under `data/data_source/`, `data/models/`, `core/lib/data/`, or `modules/data_source/`.
+- Reviewing a PR that adds or modifies a Retrofit client, repository, or DTO.
+
+## What to check
+
+### DTOs (`*_model.dart`)
+
+- [ ] `sealed class` + `@freezed`.
+- [ ] `factory FooModel.fromJson(Map<String, dynamic> json) => _$FooModelFromJson(json);` is present whenever the DTO crosses the wire.
+- [ ] Non-nullable collections have `@Default([])` / `@Default({})`.
+- [ ] `@JsonKey(name: ...)` on every non-camelCase field.
+- [ ] Enums declare `@JsonValue('…')` per variant.
+- [ ] `part 'foo_model.freezed.dart';` and `part 'foo_model.g.dart';` directives match the file name.
+- [ ] No mutable fields, no manual `==`/`hashCode` (let freezed handle it).
+
+### Retrofit clients
+
+- [ ] Annotated `@RestApi()`; abstract `factory` calls the generated `_FooApiClient`.
+- [ ] Path/query/body params use `@Path`, `@Query`, `@Body` — not interpolated strings.
+- [ ] No hard-coded base URLs or auth headers — those flow from the `Dio` instance configured in DI.
+- [ ] `Multipart` endpoints declared with `@Multipart` and `@PartFile()`.
+- [ ] No `try/catch` in the client; let `DioException` propagate.
+
+### Hive stores
+
+- [ ] Unique `@HiveType(typeId: …)`. Cross-check the existing types.
+- [ ] `@HiveField(n)` indices are stable; never reuse a deleted index.
+- [ ] Adapters registered in the DI module that owns the box.
+
+### Repositories
+
+- [ ] One repository depends on one API client (and optionally one local store) — no rich aggregation across many clients.
+- [ ] Public surface returns domain types (DTOs are fine here; entities if there's a mapper layer), never `DioException` or `Response<T>`.
+- [ ] No business decisions: branching belongs in the use case or bloc, not the repo.
+- [ ] Registered with `@LazySingleton(as: Foo)` (or `@Injectable`/`@Singleton`) and reachable from `injector`.
+
+### DI
+
+- [ ] Retrofit clients are produced from a `@module` (so `Dio` can be injected) — not direct `@LazySingleton` on the abstract class.
+- [ ] `@injectable` annotations placed on impls, not interfaces, when both exist.
+
+## Output format
+
+Reply with:
+
+1. **Verdict** — Approve / Minor changes / Blocking issues.
+2. **Blocking issues** — concrete file:line citations with corrected snippets.
+3. **Suggestions** — non-blocking improvements (naming, defaults, narrower types).
+4. **Praise** — call out what's done right.
+
+## Red flags
+
+- DTOs with `class` instead of `sealed class` (will compile but blocks future union extensions).
+- A `Repository` that imports `package:dio/dio.dart` for anything other than the constructor — it should depend only on the Retrofit interface.
+- A new `typeId` that collides with an existing hive type elsewhere in the repo.
+- Generated files (`*.freezed.dart`, `*.g.dart`) edited by hand.
+
+## Related
+
+- [`data-layer`](../data-layer/SKILL.md)
+- [`code-generation`](../code-generation/SKILL.md)
+- [`flutter-reviewer`](../flutter-reviewer/SKILL.md)

--- a/.agents/skills/error-handling/SKILL.md
+++ b/.agents/skills/error-handling/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: error-handling
+description: Routes thrown errors through CoreBlocBase + CoreDelegate to StateBase's ErrorType-driven dialog/snackbar/login UI rather than a custom Failure type
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+  framework: flutter
+  pattern: error-handling
+---
+
+# Error Handling Skill
+
+## When to use
+
+- Deciding what to do with a thrown error inside a bloc handler.
+- Tweaking the user-facing message or routing for a specific error type.
+- Adding bespoke recovery (silent retry, optimistic rollback, redirect) on top of the default UI.
+
+## End-to-end flow
+
+The bloc and the screen share a `CoreDelegate` mixin. The bloc *raises*
+errors and loading; the screen *registers handlers* and renders them:
+
+1. Throw inside a bloc handler → `CoreBlocBase.onError` converts via
+   `ErrorData.fromObject` and calls `notifyError` (skipped if the throw
+   is not an `Exception`/`Error`).
+2. The screen registered `StateBase.onError` in `initState`, so it
+   receives the `ErrorData`.
+3. `StateBase` localizes Firebase codes, calls `hideLoading()`, dedupes
+   on `errorTypeShowing == error.type`, computes `getErrorMsg`, then
+   routes by `ErrorType`:
+
+| `ErrorType` | UI |
+|---|---|
+| `unauthorized` | `showLoginRequired` → `backToAuth` |
+| `badResponse` + 5xx | `showErrorDialog` |
+| `badResponse` + 4xx | `onClientError` (default `showErrorDialog`) |
+| `timeout` / `noInternet` | online: `showErrorDialog`; offline: `showNoInternetDialog` |
+| `serverUnExpected` / `internalServerError` / `restricted` / `dataParsing` | `showErrorDialog` |
+| anything else | dev: `showErrorDialog`; prod: log only |
+
+Loading rides the same plumbing: `bloc.showLoading()` (inherited from
+`CoreDelegate`) fans out to every registered screen, which calls its
+own `showLoading()` (the EasyLoading wrapper on `CoreStateBase`). The
+two methods deliberately share names — bloc-side is fan-out, screen-side
+is the actual UI call.
+
+## Pieces in `core/`
+
+| File | What it provides |
+|---|---|
+| `core/lib/data/data_source/remote/api_service_error.dart` | `ErrorData`, `ErrorType` (`noInternet`, `timeout`, `unauthorized`, `unknown`, `badResponse`, `serverUnExpected`, `internalServerError`, `restricted`, `dataParsing`), `ErrorOrigin` (`dio`, `graphql`, `firebase`); `ErrorData.fromDio`, `.fromError`, `.fromException`, `.fromObject` |
+| `core/lib/presentation/base/delegate.dart` | `CoreDelegate` mixin: `notifyError`, `addErrorHandler`/`removeErrorHandler`, `showLoading`/`hideLoading`, `addLoadingHandler`/`removeLoadingHandler`, `clear()` |
+| `core/lib/presentation/base/bloc/bloc_base.dart` | `CoreBlocBase` mixes in `CoreDelegate`; overrides `onError` to convert + `notifyError`; calls `clear()` on `close()` |
+| `core/lib/presentation/base/state_base/state_base.dart` | `CoreStateBase`: registers `onError` + `invokeLoading` against `delegate?` in `initState`; provides `showLoading`/`hideLoading` (EasyLoading), `showErrorDialog`, `showLoginRequired`, `showNoInternetDialog`, `onClientError`, `backToAuth`, `doLogout`, `loading` widget |
+| `core/lib/presentation/base/state_base/state_base.error_handler.dart` | `_onError`, `_handleErrorByType`, `getErrorMsg` (overridable), `_connectivityErrorOrNot` |
+| `apps/main/lib/presentation/base/state_base/state_base.dart` | App-level `StateBase`: overrides `delegate => bloc`, implements `backToAuth` to open sign-in, augments `doLogout` |
+
+`ErrorData.fromDio` is the single most important reader: it parses the
+response body through `ApiResponse`, pulls out `message` + `messageKey`,
+maps `DioExceptionType` → `ErrorType`, and special-cases 401 / `invalidToken`
+/ `userNotFound` → `unauthorized`.
+
+## Default path: throw and let it route
+
+Don't `try/catch` defensively. The framework wants the throw.
+
+```dart
+Future<void> _onSubmit(SubmitEvent event, Emitter<FeatureState> emit) async {
+  showLoading();   // CoreDelegate — wakes every registered screen loader
+  try {
+    final receipt = await _usecase.submit(event.payload);
+    emit(state.copyWith<FeatureSuccess>(
+      data: state.data.copyWith(receipt: receipt),
+    ));
+  } finally {
+    hideLoading();
+  }
+}
+```
+
+If `_usecase.submit` throws a `DioException`, `CoreBlocBase.onError`
+catches it, converts to `ErrorData`, and the screen renders the right UI
+without any explicit emit. Don't also `emit(...errorState)` afterwards —
+the bloc may already have closed by the time the dialog is dismissed.
+
+## When to catch
+
+Catch only the case you can recover from in-handler. Let the rest fall
+through.
+
+```dart
+try {
+  await _usecase.submit(event.payload);
+} on DioException catch (e) when (e.response?.statusCode == 409) {
+  // Optimistic-merge conflict — silent re-fetch, no dialog.
+  add(GetFeatureEvent(event.id));
+  return;
+}
+// Any other exception bubbles to CoreBlocBase.onError.
+```
+
+For domain-level "soft" failures (a login form rejecting bad credentials
+inline, a stale optimistic update), emit a state — don't throw. Throws
+are for things that should pop a dialog the user has to acknowledge.
+
+## Customizing per screen
+
+Override the narrow hooks on `StateBase`, not `_onError`. The hierarchy
+is intentional: routing is centralized; presentation is overridable.
+
+| Override | When |
+|---|---|
+| `getErrorMsg(ErrorData)` | Custom message for a specific `error.type` / `statusCode`. Call `super` for defaults. |
+| `onClientError(message, error)` | Replace the default dialog for 4xx with a snackbar/banner. |
+| `showErrorDialog(message, error, {onClose})` | Switch every "show a dialog" path to a custom UI for this screen. |
+| `backToAuth({onSuccess, onSkip})` | Override sign-in opening. App-level `StateBase` already wires `context.openSignIn()`. |
+| `onCloseErrorDialog()` | Run additional cleanup when the user dismisses an error. Call `super` to clear `errorTypeShowing`. |
+| `willHandleError` | Return `false` to opt the screen out of automatic registration entirely (rare; for screens with their own bespoke flow). |
+
+Per-screen example:
+
+```dart
+class _FeatureScreenState extends StateBase<FeatureScreen> {
+  @override
+  String getErrorMsg(ErrorData error) {
+    if (error.type == ErrorType.badResponse && error.statusCode == 422) {
+      return trans.featureValidationError;
+    }
+    return super.getErrorMsg(error);
+  }
+
+  @override
+  void onClientError(String? message, ErrorData error) {
+    // 4xx → inline banner instead of the default dialog.
+    _bannerController.show(message ?? trans.somethingWrong);
+    onCloseErrorDialog();   // clear errorTypeShowing so dedupe doesn't lock us out
+  }
+}
+```
+
+## Dedup behaviour
+
+`errorTypeShowing` is set when a dialog opens and cleared on close.
+While set, identical-typed errors are suppressed. That's why a
+custom handler must call `onCloseErrorDialog()` (or `super`) when its
+banner/dialog dismisses — otherwise the user sees one error and then
+nothing for follow-ups of the same type.
+
+## Things that aren't routed
+
+`ErrorData.fromObject` returns `null` for things that aren't `Exception`
+or `Error` (e.g. you `throw 'string'` or `throw 42`). `CoreBlocBase`
+falls through to `super.onError`, which just logs. If you genuinely
+want a string error to surface, throw an `Exception('...')`.
+
+`DioExceptionType.cancel` and `badCertificate` leave `ErrorData.type`
+as `unknown` — in prod, those are silenced; in dev, you see the dialog.
+
+## Checklist
+
+- [ ] Bloc handlers throw / rethrow — no defensive `catch (_) {}`.
+- [ ] Loading uses `showLoading()` / `hideLoading()` from inside the bloc (CoreDelegate fan-out), `try/finally` paired.
+- [ ] No reimplementing `Failure` / `Result<T, F>` for cross-cutting use.
+- [ ] When a screen overrides routing (e.g. `onClientError`), it calls `onCloseErrorDialog()` to clear the `errorTypeShowing` lock.
+- [ ] When a screen needs a different message, it overrides `getErrorMsg` (and falls back to `super`), not `_onError`.
+- [ ] App-level `backToAuth` is wired to the actual sign-in flow (it is, in `apps/main/lib/presentation/base/state_base/state_base.dart`).
+
+## Common mistakes
+
+- Wrapping every handler in `try { ... } catch (e) { /* ignore */ }` — the spinner sticks because nothing calls `hideLoading()`, and the user sees no error UI.
+- Re-emitting an error state after `rethrow` in a bloc — handler logic continues against a possibly-closed bloc, and `_factories` may not have a matching state class.
+- Calling the screen's `showLoading()` from a bloc — that's the wrong `showLoading`; use the delegate version (it's the one in scope inside `CoreBlocBase`).
+- Forgetting to throw an `Exception` — a bare `throw 'oops'` is silently logged and doesn't show a dialog.
+- Building a per-screen banner that never clears `errorTypeShowing`, so the second 4xx of the same kind is dropped.
+
+## Related
+
+- [`bloc-pattern`](../bloc-pattern/SKILL.md)
+- [`data-layer`](../data-layer/SKILL.md)
+- [`testing`](../testing/SKILL.md)

--- a/.agents/skills/extension-action/SKILL.md
+++ b/.agents/skills/extension-action/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: extension-action
+description: Extracts screen handlers and bloc listeners into a part-of "*.action.dart" extension file
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+  framework: flutter
+  pattern: extension-action
+---
+
+# Extension Action Skill
+
+## When to use
+
+- A screen file has grown past ~100 lines mixing UI + handlers.
+- You need to add `_blocListener`, `onRefresh`, navigation handlers, or form callbacks to an existing screen.
+- Generator output is the canonical shape — every generated module already comes with this split.
+
+## File pair
+
+```
+<feature>_screen.dart   // UI + state controllers + part 'feature.action.dart';
+<feature>.action.dart   // part of '<feature>_screen.dart';
+                        // extension on _<Feature>ScreenState { ... }
+```
+
+`feature.action.dart` (note: dot, not underscore — matches generator output) is one library with the screen, so it can call private members of `_<Feature>ScreenState`.
+
+## Reference
+
+`<feature>_screen.dart`:
+
+```dart
+import 'package:core/core.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/generated/app_localizations.dart';
+import '../../../base/base.dart';
+import '../bloc/<feature>_bloc.dart';
+
+part '<feature>.action.dart';
+
+class FeatureScreen extends StatefulWidget {
+  static String routeName = '/feature';
+  const FeatureScreen({super.key, this.args});
+
+  final FeatureArgs? args;
+
+  @override
+  State<FeatureScreen> createState() => _FeatureScreenState();
+}
+
+class _FeatureScreenState extends StateBase<FeatureScreen> {
+  final _refreshController = RefreshController(initialRefresh: true);
+
+  @override
+  FeatureBloc get bloc => BlocProvider.of(context);
+
+  late ThemeData _themeData;
+  TextTheme get textTheme => _themeData.textTheme;
+  late AppLocalizations trans;
+
+  @override
+  Widget build(BuildContext context) {
+    _themeData = context.theme;
+    trans = translate(context);
+
+    return BlocListener<FeatureBloc, FeatureState>(
+      listener: _blocListener,
+      child: ScreenForm(
+        title: trans.featureTitle,
+        child: SmartRefresher(
+          controller: _refreshController,
+          onRefresh: onRefresh,
+          child: const FeatureBody(),
+        ),
+      ),
+    );
+  }
+}
+```
+
+`<feature>.action.dart`:
+
+```dart
+part of '<feature>_screen.dart';
+
+extension on _FeatureScreenState {
+  void _blocListener(BuildContext context, FeatureState state) {
+    hideLoading();
+    _refreshController.refreshCompleted();
+  }
+
+  void onRefresh() {
+    final id = widget.args?.id ?? widget.args?.initial?.id;
+    if (id != null) {
+      bloc.add(GetFeatureEvent(id));
+    }
+  }
+}
+```
+
+## What goes where
+
+Action file (extension):
+- `_blocListener(BuildContext, State)` — side effects from state changes (hide loading, complete refresh, show dialog/snackbar, navigate).
+- `onRefresh`, `onLoadMore`, `onSubmit` — handlers passed to widgets.
+- Form validation that dispatches events.
+- Coordinator calls (`context.goToX(...)`).
+
+Screen file:
+- `build`, sub-`Widget _buildX()` helpers.
+- `initState` / `dispose`.
+- `TextEditingController`, `GlobalKey`, `RefreshController` declarations.
+- `bloc` getter override.
+
+## Conventions
+
+- Extension is anonymous (`extension on _FeatureScreenState`) in generated code; if you prefer a name, use `<Feature>Action` for greppability.
+- Methods can be public (`onRefresh`) when the screen passes them as callbacks, or private (`_handleX`) when only used inside the action file.
+- The `part of` line MUST be the first non-comment line of the action file.
+
+## Checklist
+
+- [ ] `part 'feature.action.dart';` (note: dot) directive in `<feature>_screen.dart`.
+- [ ] `part of '<feature>_screen.dart';` is the first line of the action file.
+- [ ] `_blocListener` calls `hideLoading()` early so the screen-level loading delegate is unstuck on every state change.
+- [ ] No widget `build` logic in the action file.
+- [ ] No coordinator/`context.goToX` calls inside `build` — keep them in the action file.
+
+## Related
+
+- [`bloc-pattern`](../bloc-pattern/SKILL.md)
+- [`module-scaffold`](../module-scaffold/SKILL.md)
+- [`route-config`](../route-config/SKILL.md)

--- a/.agents/skills/flutter-reviewer/SKILL.md
+++ b/.agents/skills/flutter-reviewer/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: flutter-reviewer
+description: Reviews UI-layer changes — screens, blocs, widgets, routes — against the template's StateBase + AppBlocBase + fl_theme conventions
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+  framework: flutter
+  pattern: code-review
+---
+
+# Flutter UI Reviewer Skill
+
+## When to use
+
+- A diff touches files under `presentation/`, including screens, blocs, routes, coordinators, and shared widgets.
+
+## What to check
+
+### Bloc shape
+
+- [ ] Bloc extends `AppBlocBase<E, S>` (not `Bloc`/`Cubit` directly) and is `@Injectable()`.
+- [ ] `<feature>_bloc.dart` has the three `part` directives (freezed/event/state) in the right order.
+- [ ] `_StateData` is `@freezed sealed class` with `@Default(...)` on collections.
+- [ ] Concrete state classes are `extends FeatureState` (abstract base), **not** a freezed union — and every concrete class is registered in `_factories`.
+- [ ] Events extend the abstract `<X>Event` — no freezed unions for events either.
+- [ ] Long handlers call `showLoading()` / `hideLoading()` (the CoreDelegate fan-out) inside `try/finally`; no ad-hoc spinners.
+- [ ] Errors thrown / rethrown rather than silently caught (see `error-handling`).
+
+### Screen widget
+
+- [ ] Screen extends `StatefulWidget`; state extends `StateBase<T>` (not raw `State<T>`).
+- [ ] `bloc` getter overridden to `BlocProvider.of(context)`.
+- [ ] `static String routeName` declared, leading slash, lowercase.
+- [ ] Wraps in `ScreenForm` / `MainPageForm` rather than raw `Scaffold + AppBar` unless there's a reason.
+- [ ] Translates via `trans = translate(context)` or `context.l10n`; no hardcoded user-facing strings.
+- [ ] Action file (`<feature>.action.dart`) is a `part of` the screen and holds `_blocListener`, `onRefresh`, etc.
+
+### Routing
+
+- [ ] Route extends `IRoute` and exposes `List<CustomRouter>` from `routers()`.
+- [ ] `CustomRouter<Args>` (typed) when extras are non-null.
+- [ ] Builder wraps the screen in `BlocProvider`; bloc created via `injector.get(...)`.
+- [ ] `extraFromUrlQueries` set when the screen should be deep-linkable.
+- [ ] Coordinator extension on `BuildContext` exposes typed `goToX`, all taking a `PushBehavior`.
+- [ ] No direct `package:go_router/go_router.dart` imports in feature code.
+
+### Theming
+
+- [ ] No `BrandColor.*` references (it doesn't exist here).
+- [ ] No raw `Colors.white`/`Colors.black` for surfaces or text — use `context.themeColor.*`.
+- [ ] Typography uses Material 3 slot names (`titleMedium`, `bodySmall`, …) plus the `AppTextTheme` extras (`titleTiny`, `inputTitle`, `buttonText`, …) — not invented tokens like `titleMd`/`bodyXs`.
+- [ ] Buttons reuse `ThemeButton.*` defaults; per-call `style:` overrides are scoped, not redundant.
+
+### Performance
+
+- [ ] `const` constructors used wherever inputs are constant.
+- [ ] Long lists use `ListView.builder` / `Sliver*` — not `ListView(children: items.map(...).toList())`.
+- [ ] Heavy subtrees consider `RepaintBoundary` when independently animating.
+- [ ] No `setState` inside `build`.
+
+### Style
+
+- [ ] No trailing dead code, no commented-out blocks.
+- [ ] Comments explain *why*, not *what*.
+- [ ] `final` over `var` where the variable is not reassigned.
+- [ ] Imports grouped (dart, flutter, package, project relative) and trimmed.
+
+## Output format
+
+Reply with:
+
+1. **Verdict** — Approve / Minor changes / Blocking issues.
+2. **Blocking issues** — file:line citations with corrected snippets.
+3. **Suggestions** — non-blocking improvements.
+4. **Praise** — what's done right.
+
+## Red flags
+
+- A new state class added to `<feature>_state.dart` without a matching `_factories` entry (runtime crash on first `copyWith<T>()`).
+- A screen whose `_blocListener` doesn't call `hideLoading()` on every state — the loading indicator can stick.
+- A coordinator method built with literal route paths instead of `<Screen>.routeName`.
+- A `Text(...)` with a literal English string anywhere in production code.
+- `setState` inside a `BlocBuilder.builder` (rebuild loop).
+
+## Related
+
+- [`bloc-pattern`](../bloc-pattern/SKILL.md)
+- [`extension-action`](../extension-action/SKILL.md)
+- [`route-config`](../route-config/SKILL.md)
+- [`theme-usage`](../theme-usage/SKILL.md)
+- [`data-reviewer`](../data-reviewer/SKILL.md)

--- a/.agents/skills/localization/SKILL.md
+++ b/.agents/skills/localization/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: localization
+description: Adds and updates app strings through the CSV → ARB → generated AppLocalizations workflow
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+  framework: flutter
+  pattern: localization
+---
+
+# Localization Skill
+
+## When to use
+
+- Adding a translatable string to a screen.
+- Renaming or removing existing keys.
+- Adding a new locale.
+
+## Workflow
+
+The CSV is the source of truth — **never** hand-edit the generated ARB or Dart files.
+
+```
+apps/main/lib/l10n/
+├── localizations.csv        # source of truth
+├── intl_en.arb              # generated from CSV
+├── intl_th.arb              # generated from CSV
+├── localization_ext.dart    # context.l10n extension
+└── generated/
+    ├── app_localizations.dart
+    ├── app_localizations_en.dart
+    └── app_localizations_th.dart
+```
+
+`l10n.yaml` (in `apps/main/`) wires the generation step. After editing `localizations.csv`:
+
+```bash
+make lang
+```
+
+That regenerates `intl_*.arb` and the `AppLocalizations` Dart files.
+
+## CSV format
+
+The header is `key,en,th` (extend with more locale columns as locales are added). One row per string.
+
+```csv
+key,en,th
+inform,Inform,แจ้งเตือน
+ok,Ok,ตกลง
+loginRequired,Please login to continue,กรุณาเข้าสู่ระบบเพื่อดำเนินการต่อ
+welcomeMessage,"Welcome, {0}!","สวัสดี {0}!"
+```
+
+Rules:
+
+- Key names: lowerCamelCase, descriptive of meaning (`loginRequired`, not `auth_msg_2`). No prefix conventions — namespace via the key itself.
+- Quote the value if it contains a comma. Quote both columns if you quote one, to keep the diff readable.
+- Parameters are **positional** (`{0}`, `{1}`, …) — the generator does not support named placeholders here.
+- Keep keys flat across the whole app. If two screens need slightly different copy, give them distinct keys.
+
+## Using strings in the UI
+
+The screen-state `StateBase` already exposes `trans` via the generator template:
+
+```dart
+class _FeatureScreenState extends StateBase<FeatureScreen> {
+  late AppLocalizations trans;
+
+  @override
+  Widget build(BuildContext context) {
+    trans = translate(context);
+    return ScreenForm(title: trans.featureTitle, child: ...);
+  }
+}
+```
+
+Outside a `StateBase` (or in a child widget), use the `BuildContext` extension:
+
+```dart
+import '<path>/l10n/localization_ext.dart';
+
+@override
+Widget build(BuildContext context) {
+  return Text(context.l10n.welcomeMessage('Huy'));
+}
+```
+
+`core/` shipped strings sit in `core/lib/l10n/` and are reached the same way (`coreL10n` for non-context callers; see `core/lib/l10n/`).
+
+## Adding a new locale
+
+1. Add the column header to `localizations.csv` (e.g. `key,en,th,vi`).
+2. Fill in the column for every existing row — empty cells fall back to `en`.
+3. Run `make lang`. A new `intl_<locale>.arb` and `app_localizations_<locale>.dart` are produced.
+4. Add the locale to `MaterialApp.supportedLocales` (already wired from `AppLocalizations.supportedLocales` in `app_delegate.dart`).
+
+## Translation round-trip
+
+For sending strings out to translators and folding the result back, the template ships:
+
+- `make gen_translation` — emits a CSV with status columns ready for translators.
+- `make apply_translation` — folds the completed CSV back into `localizations.csv`.
+
+See `tools/module_generator/bin/generate_translation_csv.dart` and `apply_translation.dart` for behavior.
+
+## Checklist
+
+- [ ] Key added to `localizations.csv` with values for every existing locale column.
+- [ ] No translation entered into the generated `*.arb` or `app_localizations_*.dart` files.
+- [ ] `make lang` run; generated files staged.
+- [ ] Use site reaches strings via `trans.<key>` or `context.l10n.<key>`, never a hardcoded `Text('...')`.
+- [ ] Parameters use positional `{0}`, `{1}`.
+
+## Common mistakes
+
+- Editing `intl_en.arb` directly — the next `make lang` overwrites it.
+- Using `{name}` placeholders — they aren't supported; use `{0}`.
+- Sneaking in raw `Text('Save')` — pull it through the CSV.
+- Trying to namespace by file path; just give the key a precise name.
+
+## Related
+
+- [`module-scaffold`](../module-scaffold/SKILL.md)
+- [`theme-usage`](../theme-usage/SKILL.md)

--- a/.agents/skills/module-scaffold/SKILL.md
+++ b/.agents/skills/module-scaffold/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: module-scaffold
+description: Scaffolds a new feature module under apps/main/lib/presentation/modules using the bundled module generator
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+  framework: flutter
+  pattern: clean-architecture
+---
+
+# Module Scaffold Skill
+
+## When to use
+
+- Adding a new feature/screen to `apps/main/`.
+- Creating the standard module quartet: `bloc/`, `views/`, `route`, `coordinator`.
+- Spinning up a parallel data-layer model/repository/usecase for that feature.
+
+## Preferred path: bundled module generator
+
+The template ships an interactive generator that emits files matching the project's exact conventions. Always try this first.
+
+```bash
+make run_module_generator
+# Choose: 1) common module  2) listing module  3) detail module
+#         4) repository    5) usecase          6) model
+```
+
+Source: `tools/module_generator/`, templates in `tools/module_generator/lib/res/templates/`.
+
+| Module type | What it scaffolds | Use for |
+|---|---|---|
+| `common module` | Bloc + screen + route + coordinator with no list/detail bias | Forms, single-action screens |
+| `listing module` | List bloc with `items`, `canLoadMore`, refresh+load-more events | Browse/search screens |
+| `detail module` | Detail bloc parameterised by `Args(initial, id)`, `Get<X>Event` | Item detail screens |
+| `repository` | Repo + impl in `apps/main/lib/data/data_source/` | Wrap a Retrofit client |
+| `usecase` | Usecase class in `apps/main/lib/domain/usecases/` | Wrap a repository |
+| `model` | Freezed model template under `core/` or app | DTO between API and UI |
+
+After generating, run `make gen_all` so freezed/injectable code is emitted, then register the new route.
+
+## File layout (what the generator produces)
+
+```
+apps/main/lib/presentation/modules/<feature>/
+├── <feature>.dart                # Barrel: exports route/bloc/screen/coordinator
+├── <feature>_route.dart          # IRoute → CustomRouter<Args>
+├── <feature>_coordinator.dart    # extension on BuildContext
+├── bloc/
+│   ├── <feature>_bloc.dart       # part directives for event/state/freezed
+│   ├── <feature>_event.dart      # abstract class + concrete events
+│   └── <feature>_state.dart      # _StateData (freezed) + state classes + _factories
+└── views/
+    ├── <feature>_screen.dart     # StatefulWidget → StateBase<>
+    ├── <feature>.action.dart     # part of screen — handlers/listeners
+    └── widgets/                  # screen-local widgets (optional)
+```
+
+Domain + data live alongside, not under `presentation/`:
+
+```
+apps/main/lib/domain/usecases/<feature>/<feature>_usecase.dart
+apps/main/lib/data/data_source/<feature>_repository.dart  (and *_impl.dart)
+```
+
+For shared widgets/services, add to `core/` instead of `apps/main/`.
+
+## Manual scaffold (when the generator does not fit)
+
+Stick to the names below — `_factories`, `Args`, `routeName`, the part wiring — because other parts of the codebase rely on them.
+
+1. Create the directory tree above.
+2. Author the bloc/event/state with the patterns from `bloc-pattern`.
+3. Author the screen + action file with `extension-action`.
+4. Add the route + coordinator with `route-config`.
+5. Register the route in the parent `IRoute` (e.g. `apps/main/lib/presentation/route/route.dart`).
+6. Wire any new injectables, then `make gen_all`.
+
+## Checklist
+
+- [ ] Tried `make run_module_generator` first.
+- [ ] Module placed under `lib/presentation/modules/<feature>/`.
+- [ ] Screen extends `StateBase<T>` and has a `static String routeName`.
+- [ ] Bloc extends `AppBlocBase<E, S>` and is `@Injectable()`.
+- [ ] Route extends `IRoute` and wraps the screen in `BlocProvider`.
+- [ ] Coordinator is an extension on `BuildContext` using `PushBehavior`.
+- [ ] Route registered in the app's parent `IRoute`.
+- [ ] `make gen_all` run; generated files committed.
+
+## Related
+
+- [`bloc-pattern`](../bloc-pattern/SKILL.md)
+- [`route-config`](../route-config/SKILL.md)
+- [`extension-action`](../extension-action/SKILL.md)
+- [`data-layer`](../data-layer/SKILL.md)

--- a/.agents/skills/route-config/SKILL.md
+++ b/.agents/skills/route-config/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: route-config
+description: Configures routes with the IRoute / CustomRouter abstractions in core and exposes navigation via a BuildContext coordinator
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+  framework: flutter
+  pattern: navigation
+---
+
+# Route Configuration Skill
+
+## When to use
+
+- Adding a new screen to the route tree.
+- Wiring sub-module routes into a parent module.
+- Exposing typed navigation entry points to callers.
+
+## What this template uses
+
+Defined in `core/lib/presentation/route/route.dart` and re-exported via `package:core/core.dart`:
+
+- `IRoute` — module-level provider; implements `routers()` returning `List<CustomRouter>`.
+- `CustomRouter<T>` — one route entry, parameterized on the type of `extra`. Supports `path`, `builder`, `extraFromUrlQueries`, and `pathVerify`.
+
+Navigation is invoked via `PushBehavior` strategies (`PushNamedBehavior`, `GoBehavior`, etc.) over a `BuildContext` extension — the "coordinator" pattern.
+
+The plugin `plugins/fl_navigation/` ships a richer variant (with `routes:`, `redirect:`, `toGoRoute()` bridges) but is **not** imported by `apps/` or `core/` here — feature code uses the core variant only.
+
+Do **not** import `package:go_router/go_router.dart` directly from feature code. Go through `IRoute`/`CustomRouter`.
+
+## Reference: route file
+
+```dart
+import 'package:core/core.dart';
+
+import '../../../di/di.dart';
+import 'bloc/feature_bloc.dart';
+import 'views/feature_screen.dart';
+
+class FeatureRoute extends IRoute {
+  @override
+  List<CustomRouter> routers() {
+    return [
+      CustomRouter<FeatureArgs>(
+        path: FeatureScreen.routeName,
+        builder: (context, uri, extra) {
+          final args = asOrNull<FeatureArgs>(extra);
+          return BlocProvider<FeatureBloc>(
+            create: (context) => injector.get(param1: args?.initial),
+            child: FeatureScreen(args: args),
+          );
+        },
+        extraFromUrlQueries: FeatureArgs.fromUrlParams,
+      ),
+    ];
+  }
+}
+```
+
+The `routeName` lives on the screen as `static String routeName = '/feature';`. `injector.get(param1: ...)` flows the `@factoryParam` from the bloc constructor.
+
+## Compound modules
+
+A parent `IRoute` aggregates child `IRoute`s with the spread operator:
+
+```dart
+class DashboardRoute extends IRoute {
+  @override
+  List<CustomRouter> routers() => [
+    ...HomeRoute().routers(),
+    ...AnalyticsRoute().routers(),
+    ...SettingsRoute().routers(),
+  ];
+}
+```
+
+The app's top-level route registry (e.g. `apps/main/lib/presentation/route/route.dart`) does the same to bring every module into the router.
+
+## Args + URL params
+
+Detail-style screens use a typed `Args` class so navigation can be either object-driven or deep-link-driven:
+
+```dart
+class FeatureArgs {
+  final Item? initial;
+  final String? id;
+
+  FeatureArgs({this.initial, this.id});
+
+  factory FeatureArgs.fromUrlParams(Map<String, dynamic> queryParameters) =>
+      FeatureArgs(id: asOrNull(queryParameters['id']));
+
+  // For web, flatten to a query map; for native, pass the rich object.
+  dynamic get adaptive {
+    if (kIsWeb) {
+      return {'id': initial?.id ?? id}..removeWhere((_, v) => v.isNullOrEmpty);
+    }
+    return this;
+  }
+}
+```
+
+`CustomRouter.buildExtra` resolves either path: a real `Args` object passed via `arguments`, or query params on a deep link.
+
+## Coordinator (navigation extension)
+
+Every module exposes its routes through a `BuildContext` extension so callers don't typo route paths:
+
+```dart
+import 'package:core/core.dart';
+import 'package:flutter/material.dart';
+
+import 'feature.dart';
+
+extension FeatureCoordinator on BuildContext {
+  Future<T?> goToFeature<T>({
+    required Item object,
+    PushBehavior pushBehavior = const PushNamedBehavior(),
+  }) async {
+    return pushBehavior.push(
+      this,
+      FeatureScreen.routeName,
+      arguments: FeatureArgs(initial: object).adaptive,
+    );
+  }
+
+  Future<T?> goToFeatureById<T>({
+    required String id,
+    PushBehavior pushBehavior = const PushNamedBehavior(),
+  }) async {
+    return pushBehavior.push(
+      this,
+      FeatureScreen.routeName,
+      arguments: FeatureArgs(id: id).adaptive,
+    );
+  }
+}
+```
+
+Callers: `context.goToFeature(object: item)` or `context.goToFeatureById(id: '42')`.
+
+## Checklist
+
+- [ ] Screen has `static String routeName` starting with `/`.
+- [ ] Route extends `IRoute` and uses `CustomRouter<Args>` (typed) when extras are non-null.
+- [ ] Builder wraps the screen in `BlocProvider` and creates the bloc via `injector.get(...)`.
+- [ ] `extraFromUrlQueries` provided when the screen should be deep-linkable.
+- [ ] Coordinator extension exposes typed `goToX` methods, all taking `PushBehavior`.
+- [ ] New `IRoute` registered in the parent / app-level `IRoute`.
+- [ ] No direct `package:go_router/go_router.dart` imports in feature code.
+
+## Common mistakes
+
+- Hard-coding route paths in callers instead of going through a coordinator.
+- Forgetting to spread sub-module `routers()` into the parent.
+- Using `extra` without an `Args` type, then casting in the screen — it loses URL-param support.
+
+## Related
+
+- [`module-scaffold`](../module-scaffold/SKILL.md)
+- [`extension-action`](../extension-action/SKILL.md)
+- [`bloc-pattern`](../bloc-pattern/SKILL.md)

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: testing
+description: Writes unit and widget tests for blocs, repositories, and screens using bloc_test + mocktail
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+  framework: flutter
+  pattern: testing
+---
+
+# Testing Skill
+
+## When to use
+
+- Adding coverage for a new bloc, repository, or screen.
+- Locking down a fixed bug with a regression test.
+- Verifying a state-machine path that's easy to break.
+
+## Layout
+
+Tests live next to the package they cover:
+
+```
+apps/main/test/                 # app-level tests
+core/test/                      # core-level tests
+modules/data_source/test/
+plugins/<plugin>/test/
+```
+
+A common shape inside `apps/main/test/`:
+
+```
+test/
+├── unit/
+│   ├── bloc/
+│   ├── domain/
+│   └── data/
+├── widget/
+└── helpers/
+```
+
+## Running tests
+
+```bash
+flutter test                                  # current package
+flutter test test/unit/bloc/foo_bloc_test.dart
+make coverage_main                            # coverage on apps/main, via coverage.sh
+```
+
+There is no `make test` / `make analyze` aggregate target — invoke `flutter test` and `flutter analyze` (or `dart analyze`) per package as needed.
+
+## Bloc tests
+
+Use `bloc_test` for sequence assertions and `mocktail` for collaborators.
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockUsecase extends Mock implements FeatureUsecase {}
+
+void main() {
+  late _MockUsecase usecase;
+  late FeatureBloc bloc;
+
+  setUp(() {
+    usecase = _MockUsecase();
+    bloc = FeatureBloc(null, usecase);
+  });
+
+  tearDown(() => bloc.close());
+
+  group('FeatureBloc', () {
+    test('initial state is FeatureInitial with empty data', () {
+      expect(bloc.state, isA<FeatureInitial>());
+      expect(bloc.state.data.detail, isNull);
+    });
+
+    blocTest<FeatureBloc, FeatureState>(
+      'GetFeatureEvent loads detail and stays in FeatureInitial',
+      build: () {
+        when(() => usecase.getById('1'))
+            .thenAnswer((_) async => Item(id: '1', name: 'A'));
+        return bloc;
+      },
+      act: (b) => b.add(GetFeatureEvent('1')),
+      expect: () => [
+        isA<FeatureInitial>().having((s) => s.detail?.id, 'detail.id', '1'),
+      ],
+    );
+  });
+}
+```
+
+Note: this template's blocs use `abstract class` state hierarchies, not freezed unions, so assert with `isA<FeatureInitial>()` plus `having(...)` rather than equality on a sealed union.
+
+## Repository tests
+
+```dart
+class _MockApi extends Mock implements UserApiClient {}
+
+void main() {
+  late _MockApi api;
+  late UserRepositoryImpl repo;
+
+  setUp(() {
+    api = _MockApi();
+    repo = UserRepositoryImpl(api);
+  });
+
+  test('getUser delegates to api client', () async {
+    final user = UserModel(id: '1', name: 'A');
+    when(() => api.getUser('1')).thenAnswer((_) async => user);
+
+    expect(await repo.getUser('1'), user);
+    verify(() => api.getUser('1')).called(1);
+  });
+}
+```
+
+## Widget tests
+
+Wrap the screen in the same providers it gets in production: a `BlocProvider` (with a mocked bloc) and `MaterialApp.router` or a plain `MaterialApp` with `Localizations` if your widget reads `context.l10n`.
+
+```dart
+class _MockBloc extends MockBloc<FeatureEvent, FeatureState>
+    implements FeatureBloc {}
+
+void main() {
+  late _MockBloc bloc;
+
+  setUp(() => bloc = _MockBloc());
+
+  Widget pump(Widget child) => MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: BlocProvider<FeatureBloc>.value(value: bloc, child: child),
+  );
+
+  testWidgets('shows empty state when items is empty', (tester) async {
+    when(() => bloc.state).thenReturn(
+      FeatureInitial(data: const _StateData()),
+    );
+    await tester.pumpWidget(pump(const FeatureScreen()));
+    expect(find.byType(EmptyData), findsOneWidget);
+  });
+}
+```
+
+For interactions, drive a real bloc through the actions extension instead of mocking — it catches more bugs.
+
+## Mocktail conventions
+
+- Always register `Fallback` values for any value-typed argument matchers (`registerFallbackValue(...)`).
+- Prefer `verifyNever`/`verifyInOrder` over loose `verify`.
+- Don't share `Mock` instances between tests — recreate in `setUp`.
+
+## Checklist
+
+- [ ] Test file mirrors the source path (`lib/.../foo_bloc.dart` ↔ `test/unit/bloc/foo_bloc_test.dart`).
+- [ ] Bloc closed in `tearDown`.
+- [ ] Each test exercises one behavior.
+- [ ] Mocked dependencies use `mocktail` consistently across the file.
+- [ ] Widget tests provide the same locale + theme + bloc context the screen needs.
+- [ ] `flutter test` passes locally before commit.
+
+## Common mistakes
+
+- Asserting on `state == FeatureLoaded(...)` — equality is reference-based on these abstract state classes; use `isA<>().having(...)`.
+- Forgetting `registerFallbackValue` for typed arguments and getting cryptic `mocktail` errors.
+- Pumping a widget without a `MaterialApp` ancestor; localizations and themes blow up.
+
+## Related
+
+- [`bloc-pattern`](../bloc-pattern/SKILL.md)
+- [`data-layer`](../data-layer/SKILL.md)
+- [`error-handling`](../error-handling/SKILL.md)

--- a/.agents/skills/theme-usage/SKILL.md
+++ b/.agents/skills/theme-usage/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: theme-usage
+description: Applies the fl_theme design system via context.themeColor and context.textTheme without hard-coded colors or Material text-style names
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+  framework: flutter
+  pattern: theming
+---
+
+# Theme Usage Skill
+
+## When to use
+
+- Styling a new widget or screen.
+- Picking colors, typography, button defaults, dividers, or borders.
+
+## What this template uses
+
+`fl_theme` (in `plugins/fl_theme/`) registers three `ThemeExtension`s on `MaterialApp`'s `ThemeData`:
+
+- `ThemeColorExtension` → semantic palette, accessed via `context.themeColor`.
+- `AppTextThemeExtension` → typography, accessed via `context.textTheme`. It extends Flutter's `TextTheme` with extra slots for inputs/buttons.
+- `ScreenTheme` → screen-form + main-page defaults, accessed via `context.screenTheme`.
+
+`fl_theme` also exports `ThemeButton.primary(context)` etc. for consistent button styling.
+
+There is **no `BrandColor`** in this template. Always go through `context.themeColor`.
+
+## Color usage
+
+```dart
+final colors = context.themeColor;
+
+Container(
+  color: colors.surface,
+  decoration: BoxDecoration(
+    border: Border.all(color: colors.borderColor),
+  ),
+  child: Text('Hi', style: TextStyle(color: colors.onBackground)),
+);
+```
+
+`ThemeColor` exposes ~50 fields grouped roughly as:
+
+- Brand: `primary` / `primaryVariant` / `secondary` / `themePrimary` (+ light/dark) and their `on*` pairs
+- Surfaces: `surface`, `background`, `cardBackground`, `canvasColor`, `scaffoldBackgroundColor`
+- Feedback: `error` / `onError`
+- Chrome: `appbarBackgroundColor`, `appbarForegroundColor`, `shadowColor`, `splashColor`
+- Lines: `borderColor`, `dividerColor`
+- State: `disableColor`, `selected`, `selectedLabelColor`, `unselectedLabelColor`
+- Buttons: `textButtonColor`, `elevatedBtn*`, `outlineButton*` (+ disabled variants)
+- Form components: `checkbox*`, `chip*`, `deleteIconColor`
+- Text-on-bg: `displayText`, `headlineText`, `titleText`, `bodyText`, `labelText`, `warningText`, `hyperLink`
+
+The full list with doc comments lives in `plugins/fl_theme/lib/src/theme_color.dart`. Use IDE autocomplete on `context.themeColor.` instead of memorizing.
+
+## Typography
+
+`context.textTheme` returns an `AppTextTheme` (subclass of Flutter's `TextTheme`). Use the **Material 3 slot names** plus the custom inputs/buttons slots:
+
+| Slot family | Names |
+|---|---|
+| Display | `displayLarge`, `displayMedium`, `displaySmall` |
+| Headline | `headlineLarge`, `headlineMedium`, `headlineSmall` |
+| Title | `titleLarge`, `titleMedium`, `titleSmall`, **`titleTiny`** (`titleSmall * 0.85`) |
+| Body | `bodyLarge`, `bodyMedium`, `bodySmall` |
+| Label | `labelLarge`, `labelMedium`, `labelSmall` |
+| Inputs | `textInput`, `inputTitle`, `inputRequired`, `inputHint`, `inputError`, `helper` |
+| Buttons | `buttonText` |
+
+```dart
+Text('Heading', style: context.textTheme.titleMedium);
+Text('Body',    style: context.textTheme.bodyMedium);
+Text('Caption', style: context.textTheme.bodySmall);
+TextField(decoration: InputDecoration(
+  labelStyle: context.textTheme.inputTitle,
+  hintStyle:  context.textTheme.inputHint,
+));
+```
+
+Customize with `copyWith`, never replace from scratch:
+
+```dart
+Text(
+  'Emphasis',
+  style: context.textTheme.bodyMedium?.copyWith(
+    fontWeight: FontWeight.w600,
+    color: context.themeColor.primary,
+  ),
+);
+```
+
+## Screen wrapper
+
+Use `ScreenForm` (`core/lib/presentation/common_widget/forms/screen_form.dart`) instead of raw `Scaffold + AppBar` — it picks up `context.screenFormTheme` automatically.
+
+```dart
+ScreenForm(
+  title: trans.featureTitle,
+  child: ...,
+);
+```
+
+`MainPageForm` is the corresponding wrapper for main-tab pages.
+
+## Buttons
+
+Lean on `ThemeButton` defaults rather than constructing `ButtonStyle` from scratch:
+
+```dart
+ElevatedButton(
+  style: ThemeButton.primary(context),
+  onPressed: _handleSubmit,
+  child: Text(trans.submit),
+);
+```
+
+When you do override, scope changes to `style: ButtonStyle(...)` rather than mixing `style:` with separate `textStyle:` (the latter is silently ignored).
+
+## Checklist
+
+- [ ] No `BrandColor.*` references — that class does not exist here.
+- [ ] No raw `Colors.white`/`Colors.black` for surfaces or text — use `context.themeColor.*`.
+- [ ] No invented text tokens (`titleMd`, `bodyXs`, `labelXs`) — use Material 3 names plus the input/button slots.
+- [ ] Screens use `ScreenForm`/`MainPageForm`, not raw `Scaffold`.
+- [ ] Buttons reuse `ThemeButton.*` defaults where possible.
+
+## Common mistakes
+
+- Mixing `Theme.of(context).textTheme` with `context.textTheme` — they return different types here. Stick with `context.textTheme`.
+- Calling `context.themeColor` inside `initState` — extensions need a built `BuildContext`; resolve in `build`/`didChangeDependencies` only.
+- Over-customizing button styling per call instead of extending `ThemeButton` once.
+
+## Related
+
+- [`extension-action`](../extension-action/SKILL.md)
+- [`module-scaffold`](../module-scaffold/SKILL.md)

--- a/.agents/teams/development-team.yaml
+++ b/.agents/teams/development-team.yaml
@@ -1,0 +1,231 @@
+# Development Team Configuration
+# AI agent roles available in this Flutter base template.
+#
+# Each member has:
+#   role            — stable internal name used in handoff rules
+#   agent           — handle the user mentions to activate it (e.g. @orchestrator)
+#   responsibilities— what the role owns
+#   triggers        — words/phrases that should auto-route to this role
+#   skills          — entries from .agents/skills/ this role should pull on
+#                     (informational; agents still resolve skills dynamically)
+
+team:
+  name: development-team
+  description: Full-cycle development team for the Flutter base template
+
+  members:
+    - role: orchestrator
+      agent: orchestrator
+      responsibilities:
+        - task_decomposition
+        - delegation
+        - quality_control
+        - workflow_coordination
+      triggers: [plan, coordinate, review, organize]
+      skills: []   # delegates to specialists; rarely loads skills directly
+
+    - role: explorer
+      agent: explorer
+      responsibilities:
+        - codebase_search
+        - file_discovery
+        - pattern_matching
+        - code_navigation
+      triggers: [find, search, locate, explore]
+      skills: []
+
+    - role: oracle
+      agent: oracle
+      responsibilities:
+        - architecture_review
+        - design_decisions
+        - code_quality_analysis
+        - strategic_planning
+      triggers: ["should I", architecture, design, review]
+      skills:
+        - bloc-pattern
+        - route-config
+        - error-handling
+        - data-layer
+        - flutter-reviewer
+        - data-reviewer
+
+    - role: security_auditor
+      agent: security-auditor
+      responsibilities:
+        - vulnerability_detection
+        - security_pattern_analysis
+        - dependency_auditing
+        - remediation_guidance
+      triggers: [security, vulnerability, audit, scan]
+      skills:
+        - data-layer            # auth, token storage, network surface
+        - error-handling        # how unauthorized + 4xx flow
+
+    - role: researcher
+      agent: researcher
+      responsibilities:
+        - external_research
+        - documentation_lookup
+        - api_reference
+        - best_practices
+      triggers: [research, documentation, API, "best practice"]
+      skills: []
+
+    - role: designer
+      agent: designer
+      responsibilities:
+        - ui_ux_design
+        - component_creation
+        - visual_design
+      triggers: [design, UI, UX, style, visual]
+      skills:
+        - theme-usage
+        - extension-action
+        - localization
+
+    - role: fixer
+      agent: fixer
+      responsibilities:
+        - implementation
+        - bug_fixes
+        - feature_development
+        - refactoring
+      triggers: [fix, implement, create, build, write]
+      skills:
+        - module-scaffold
+        - bloc-pattern
+        - extension-action
+        - route-config
+        - theme-usage
+        - data-layer
+        - localization
+        - error-handling
+        - code-generation
+        - testing
+
+    - role: git_master
+      agent: git-master
+      responsibilities:
+        - commit_creation
+        - rebase_operations
+        - history_analysis
+        - atomic_commits
+      triggers: [commit, git, rebase, history]
+      skills:
+        - code-generation       # ensure generated files are staged before commit
+
+# Handoff Protocol
+handoff:
+  protocol: explicit
+  triggers:
+    - condition: security_issue_detected
+      target: security_auditor
+      context_transfer: full
+    - condition: implementation_needed
+      target: fixer
+      context_transfer: summary
+    - condition: design_decision_required
+      target: oracle
+      context_transfer: full
+    - condition: external_research_needed
+      target: researcher
+      context_transfer: summary
+    - condition: implementation_complete
+      target: git_master
+      context_transfer: summary
+    - condition: ui_review_needed
+      target: oracle
+      context_transfer: full
+      hint: load flutter-reviewer
+    - condition: data_layer_review_needed
+      target: oracle
+      context_transfer: full
+      hint: load data-reviewer
+  termination_conditions:
+    - type: max_messages
+      value: 50
+    - type: text_mention
+      value: "TASK_COMPLETE"
+    - type: external
+      enabled: true
+
+# Collaboration Pattern
+collaboration:
+  type: swarm
+  description: Agents handoff based on task requirements
+  default_flow: |
+    1. orchestrator receives task
+    2. orchestrator decomposes and delegates
+    3. specialists complete their tasks
+    4. fixer implements changes (loads module-scaffold / bloc-pattern / etc.)
+    5. oracle reviews via flutter-reviewer or data-reviewer
+    6. git_master runs code-generation, then creates atomic commits
+    7. orchestrator verifies completion
+
+# Common workflows expressed as agent + skill chains
+workflows:
+  new_feature:
+    description: Add a new screen with bloc, route, and tests
+    chain:
+      - { agent: fixer, skills: [module-scaffold] }
+      - { agent: fixer, skills: [bloc-pattern, extension-action] }
+      - { agent: fixer, skills: [route-config] }
+      - { agent: designer, skills: [theme-usage, localization] }
+      - { agent: fixer, skills: [code-generation] }
+      - { agent: fixer, skills: [testing] }
+      - { agent: oracle, skills: [flutter-reviewer] }
+      - { agent: git_master }
+
+  api_integration:
+    description: Wrap a new endpoint into repo + bloc
+    chain:
+      - { agent: fixer, skills: [data-layer] }
+      - { agent: fixer, skills: [code-generation] }
+      - { agent: fixer, skills: [bloc-pattern] }
+      - { agent: fixer, skills: [error-handling] }
+      - { agent: fixer, skills: [testing] }
+      - { agent: oracle, skills: [data-reviewer] }
+      - { agent: git_master }
+
+  bug_fix:
+    description: Locate, root-cause, fix, and pin with a regression test
+    chain:
+      - { agent: explorer }
+      - { agent: oracle }
+      - { agent: fixer }
+      - { agent: fixer, skills: [testing] }
+      - { agent: git_master }
+
+  pr_review:
+    description: Review by area
+    chain:
+      - { agent: oracle, skills: [flutter-reviewer] }   # presentation/
+      - { agent: oracle, skills: [data-reviewer] }      # data/
+
+# Project conventions referenced by skills
+project_config:
+  skills_directory: .agents/skills
+  project_root: .
+  conventions:
+    - clean_architecture                           # presentation → domain → data
+    - bloc_pattern_with_state_data                 # AppBlocBase + abstract state hierarchy
+    - freezed_state_data                           # _StateData via @freezed sealed class
+    - extension_action_screens                     # *.action.dart part-of screen
+    - iroute_navigation_via_core                   # IRoute + CustomRouter from core/, fed into go_router
+    - fl_theme_tokens                              # context.themeColor + Material 3 text slots + AppTextTheme extras
+    - csv_localization                             # localizations.csv → ARB → AppLocalizations
+    - core_delegate_error_routing                  # CoreBlocBase.onError → StateBase ErrorType router
+  make_commands:
+    setup:                 Clean + pub_get + lang + asset + gen_all
+    pub_get:               flutter pub get across plugins, core, main
+    gen_all:               build_runner across core + data_source + main
+    gen_main:              build_runner only inside apps/main
+    gen_core:              build_runner only inside core
+    gen_data_source:       build_runner only inside modules/data_source
+    lang:                  CSV → ARB → AppLocalizations
+    asset:                 regenerate asset accessors
+    format:                dart format .
+    coverage_main:         apps/main coverage via coverage.sh
+    run_module_generator:  interactive feature scaffolder
+    build:                 interactive build picker (env × platform)


### PR DESCRIPTION
## Summary

- Adds `.agents/` — a project-local skill bundle that AI coding agents can auto-discover. Drop-in: clone the repo and the skills travel with it.
- 12 skills covering the template's actual conventions (bloc-pattern with `AppBlocBase` + abstract state hierarchy + `_StateData`/`_factories`, `IRoute` / `CustomRouter` routing, fl_theme tokens, Freezed + Retrofit data layer, `CoreBlocBase.onError` → `StateBase` `ErrorType` error router, CSV localization, build_runner workflow, etc.).
- Plus `README.md`, `INDEX.md`, `ONBOARDING.md`, `TROUBLESHOOTING.md`, and `teams/development-team.yaml` mapping agent roles to the skills they pull in and to standard workflows (new feature / API integration / bug fix / PR review).

## What's in the bundle

```
.agents/
├── README.md / INDEX.md / ONBOARDING.md / TROUBLESHOOTING.md
├── teams/development-team.yaml
└── skills/
    ├── bloc-pattern/        # AppBlocBase + _StateData + _factories
    ├── code-generation/     # make gen_all and friends
    ├── data-layer/          # Freezed DTO + Retrofit + hive_ce + repo
    ├── data-reviewer/       # PR review checklist for data/
    ├── error-handling/      # CoreDelegate routing → ErrorType UI
    ├── extension-action/    # *.action.dart for screen handlers
    ├── flutter-reviewer/    # PR review checklist for presentation/
    ├── localization/        # CSV → ARB → AppLocalizations
    ├── module-scaffold/     # make run_module_generator
    ├── route-config/        # IRoute / CustomRouter from core
    ├── testing/             # bloc_test + mocktail patterns
    └── theme-usage/         # context.themeColor + context.textTheme
```

Skill names are unprefixed so the bundle stays portable when this template is cloned into another project.

## Test plan

- [ ] Open the repo in an agent that supports `.agents/skills/` (Claude Code, OpenCode, Cursor, …) and confirm the skills are listed.
- [ ] Try a skill activation: e.g. ask the agent to "scaffold a settings module" and confirm it loads `module-scaffold` and produces output that matches `tools/module_generator/lib/res/templates/`.
- [ ] Verify that the technical claims in each `SKILL.md` are still accurate against `core/`, `apps/main/`, and `plugins/fl_theme/` (no API drift).