### PR TITLE
Add fl_theme design system playground

### DIFF
--- a/.agents/skills/flutter-reviewer/SKILL.md
+++ b/.agents/skills/flutter-reviewer/SKILL.md
@@ -53,6 +53,16 @@ metadata:
 - [ ] Typography uses Material 3 slot names (`titleMedium`, `bodySmall`, …) plus the `AppTextTheme` extras (`titleTiny`, `inputTitle`, `buttonText`, …) — not invented tokens like `titleMd`/`bodyXs`.
 - [ ] Buttons reuse `ThemeButton.*` defaults; per-call `style:` overrides are scoped, not redundant.
 - [ ] Existing project controls are reused before custom UI is introduced.
+- [ ] Shared spacing, radii, padding, and elevations use `context.decorationTheme` where reusable theme tokens apply.
+- [ ] Theme JSON/configuration UI keeps preview-only state separate from serialized theme config.
+
+### Interactive examples and playgrounds
+
+- [ ] Presets/imports do not leave stale form fields; use controlled editors, synced controllers, or keyed rebuilds.
+- [ ] Narrow layouts avoid fixed heights that clip tab views or preview content.
+- [ ] JSON import/export, invalid JSON errors, preset switching, and preview-only toggles are covered by tests or smoke checks.
+- [ ] Preview surfaces cover disabled/error/menu/navigation states when the playground claims to demonstrate component theming.
+- [ ] A real browser smoke check was run for web playground changes when possible, including console warnings/errors.
 
 ### Performance
 
@@ -86,6 +96,8 @@ Reply with:
 - A custom control recreated when an existing project widget already fits.
 - A `Text(...)` with a literal English string anywhere in production code.
 - `setState` inside a `BlocBuilder.builder` (rebuild loop).
+- A playground editor using stale `initialValue` fields after imported/preset state changes.
+- Preview-only example options leaking into serialized runtime JSON.
 
 ## Related
 

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -48,7 +48,7 @@ flutter test test/unit/bloc/foo_bloc_test.dart
 make coverage_main                            # coverage on apps/main, via coverage.sh
 ```
 
-There is no `make test` / `make analyze` aggregate target — invoke `flutter test` and `flutter analyze` (or `dart analyze`) per package as needed.
+Use project make targets when they exist; otherwise invoke `flutter test` and `flutter analyze` (or `dart analyze`) per package as needed. Do not assume every branch has aggregate analyze/test targets.
 
 ## Bloc tests
 

--- a/.agents/skills/theme-usage/SKILL.md
+++ b/.agents/skills/theme-usage/SKILL.md
@@ -18,13 +18,14 @@ metadata:
 
 ## What this template uses
 
-`fl_theme` (in `plugins/fl_theme/`) registers three `ThemeExtension`s on `MaterialApp`'s `ThemeData`:
+`fl_theme` (in `plugins/fl_theme/`) builds app themes from an `AppDesignSystem` or a `ThemeJsonConfig`, then registers semantic extensions on `MaterialApp`'s `ThemeData`:
 
 - `ThemeColorExtension` → semantic palette, accessed via `context.themeColor`.
 - `AppTextThemeExtension` → typography, accessed via `context.textTheme`. It extends Flutter's `TextTheme` with extra slots for inputs/buttons.
 - `ScreenTheme` → screen-form + main-page defaults, accessed via `context.screenTheme`.
+- `AppDecorationTheme` → spacing, radius, padding, border, and elevation tokens, accessed via `context.decorationTheme`.
 
-`fl_theme` also exports `ThemeButton.primary(context)` etc. for consistent button styling.
+`fl_theme` also exports `AppTheme.create(AppThemeConfig(designSystem: ...))`, JSON DTOs for portable theme configuration, and `ThemeButton.primary(context)` etc. for consistent button styling.
 
 There is **no `BrandColor`** in this template. Always go through `context.themeColor`.
 
@@ -55,6 +56,23 @@ Container(
 - Text-on-bg: `displayText`, `headlineText`, `titleText`, `bodyText`, `labelText`, `warningText`, `hyperLink`
 
 The full list with doc comments lives in `plugins/fl_theme/lib/src/theme_color.dart`. Use IDE autocomplete on `context.themeColor.` instead of memorizing.
+
+## Decoration tokens
+
+Use `context.decorationTheme` for reusable spacing, radius, padding, borders, and elevations instead of scattering raw layout numbers through reusable UI.
+
+```dart
+final decoration = context.decorationTheme;
+
+Card(
+  elevation: decoration.elevationSm,
+  shape: RoundedRectangleBorder(borderRadius: decoration.radiusMdBorder),
+  child: Padding(
+    padding: EdgeInsets.all(decoration.spaceMd),
+    child: child,
+  ),
+);
+```
 
 ## Typography
 
@@ -105,6 +123,12 @@ ScreenForm(
 
 `MainPageForm` is the corresponding wrapper for main-tab pages.
 
+## JSON themes and playground
+
+Use `ThemeJsonConfig` for portable theme import/export and `AppDesignSystem.fromJsonConfig` to compose runtime theme pieces. Keep preview-only UI choices, such as device-frame wrappers in examples, outside the JSON schema.
+
+The canonical interactive example is `plugins/fl_theme/example`. When changing theme configuration behavior, update or smoke-test that playground so JSON import/export, presets, controls, and preview components remain aligned.
+
 ## Buttons
 
 Lean on `ThemeButton` defaults rather than constructing `ButtonStyle` from scratch:
@@ -126,6 +150,8 @@ When you do override, scope changes to `style: ButtonStyle(...)` rather than mix
 - [ ] No invented text tokens (`titleMd`, `bodyXs`, `labelXs`) — use Material 3 names plus the input/button slots.
 - [ ] Screens use `ScreenForm`/`MainPageForm`, not raw `Scaffold`.
 - [ ] Buttons reuse `ThemeButton.*` defaults where possible.
+- [ ] Shared spacing/radius/elevation reads from `context.decorationTheme` where those tokens apply.
+- [ ] Theme JSON stays portable; preview-only example state is not serialized.
 
 ## Common mistakes
 

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ app.*.map.json
 *.info
 test/.test_coverage.dart
 .claude/settings.local.json
+
+# Playwright related
+.playwright-mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,7 +425,7 @@ flutter analyze    # From the relevant package if no make target is available
 flutter test       # From the relevant package if tests exist
 ```
 
-For UI changes, run the app and smoke-test the affected flow before reporting completion whenever possible. If you cannot run the UI in this environment, say so explicitly.
+For UI changes, run the app and smoke-test the affected flow before reporting completion whenever possible. For interactive web examples or playgrounds, prefer Playwright MCP or another real browser check that covers the golden path, responsive layout, import/export flows, invalid input handling, and browser console errors. If you cannot run the UI in this environment, say so explicitly.
 
 ## Final Reminders
 

--- a/apps/main/lib/presentation/app.dart
+++ b/apps/main/lib/presentation/app.dart
@@ -47,6 +47,14 @@ class _MyAppState extends State<MainApplication>
   }
 
   @override
+  void didChangePlatformBrightness() {
+    super.didChangePlatformBrightness();
+    if (appBloc.state.themeMode == ThemeMode.system) {
+      _updateStatusBarColor();
+    }
+  }
+
+  @override
   void afterFirstLayout(BuildContext context) {
     _updateStatusBarColor();
   }
@@ -57,11 +65,36 @@ class _MyAppState extends State<MainApplication>
     }
   }
 
+  void _scheduleStatusBarUpdate() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _updateStatusBarColor();
+      }
+    });
+  }
+
   void _updateStatusBarColor() {
-    if (appBloc.state.themeMode == ThemeMode.dark) {
-      globalNavigatorKey.currentContext?.themeColor.setDarkStatusBar();
+    final currentContext = globalNavigatorKey.currentContext;
+    if (currentContext == null) {
+      return;
+    }
+
+    final themeColor = currentContext.themeColor;
+    if (_effectiveBrightness(currentContext) == Brightness.dark) {
+      themeColor.setDarkStatusBar();
     } else {
-      globalNavigatorKey.currentContext?.themeColor.setLightStatusBar();
+      themeColor.setLightStatusBar();
+    }
+  }
+
+  Brightness _effectiveBrightness(BuildContext context) {
+    switch (appBloc.state.themeMode) {
+      case ThemeMode.dark:
+        return Brightness.dark;
+      case ThemeMode.light:
+        return Brightness.light;
+      case ThemeMode.system:
+        return MediaQuery.platformBrightnessOf(context);
     }
   }
 
@@ -72,10 +105,14 @@ class _MyAppState extends State<MainApplication>
         BlocProvider(create: (_) => appBloc),
         BlocProvider(create: (_) => injector<LocationCubit>()),
       ],
-      child: BlocBuilder<AppGlobalBloc, AppGlobalState>(
-        builder: (context, state) {
-          return _buildApplication(state, context);
+      child: BlocConsumer<AppGlobalBloc, AppGlobalState>(
+        listenWhen: (previous, current) {
+          return previous.themeMode != current.themeMode ||
+              previous.lightTheme != current.lightTheme ||
+              previous.darkTheme != current.darkTheme;
         },
+        listener: (_, _) => _scheduleStatusBarUpdate(),
+        builder: (context, state) => _buildApplication(state, context),
       ),
     );
   }

--- a/apps/main/lib/presentation/theme/screen_theme.dart
+++ b/apps/main/lib/presentation/theme/screen_theme.dart
@@ -1,43 +1,15 @@
 import 'package:core/core.dart';
 
-class AppScreenFormTheme extends ScreenFormTheme {
-  AppScreenFormTheme(AppTextTheme textTheme)
-    : super(
-        showHeaderImage: false,
-        hasBottomBorderRadius: false,
-        showAppbarDivider: false,
-        centerTitle: false,
-        titleStyle: textTheme.bodyLarge,
-      );
-}
+class AppScreenThemes {
+  AppScreenThemes._();
 
-class AppMainPageFormTheme extends MainPageFormTheme {
-  AppMainPageFormTheme(AppTextTheme textTheme)
-    : super(
-        showHeaderImage: false,
-        hasBottomBorderRadius: false,
-        showAppbarDivider: false,
-        titleStyle: textTheme.bodyLarge,
-      );
-}
-
-class AppScreenFormDarkTheme extends ScreenFormTheme {
-  AppScreenFormDarkTheme(AppTextTheme textTheme)
-    : super(
-        showHeaderImage: false,
-        hasBottomBorderRadius: false,
-        showAppbarDivider: false,
-        centerTitle: false,
-        titleStyle: textTheme.bodyLarge,
-      );
-}
-
-class AppMainPageFormDarkTheme extends MainPageFormTheme {
-  AppMainPageFormDarkTheme(AppTextTheme textTheme)
-    : super(
-        showHeaderImage: false,
-        hasBottomBorderRadius: false,
-        showAppbarDivider: false,
-        titleStyle: textTheme.bodyLarge,
-      );
+  static ScreenTheme create(AppTextTheme textTheme) {
+    return ScreenTheme.fromTextTheme(
+      textTheme,
+      showHeaderImage: false,
+      hasBottomBorderRadius: false,
+      showAppbarDivider: true,
+      centerTitle: true,
+    );
+  }
 }

--- a/apps/main/lib/presentation/theme/theme.dart
+++ b/apps/main/lib/presentation/theme/theme.dart
@@ -1,5 +1,4 @@
 import 'package:core/core.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'screen_theme.dart';
@@ -12,49 +11,32 @@ class MainAppTheme {
   const MainAppTheme({required this.light, required this.dark});
 
   factory MainAppTheme.normal() {
-    return MainAppTheme(light: _buildLightTheme(), dark: _buildDarkTheme());
-  }
-
-  static AppTheme _buildLightTheme() {
-    final themeColor = AppThemeColor();
-    final textTheme = _createTextTheme(themeColor);
-
-    return AppTheme.factory(
-      screenTheme: _createScreenTheme(
-        screenFormTheme: AppScreenFormTheme(textTheme),
-        mainPageFormTheme: AppMainPageFormTheme(textTheme),
-      ),
-      appTextTheme: textTheme,
-      themeColor: themeColor,
-      targetPlatform: _getTargetPlatform(),
+    return MainAppTheme(
+      light: _buildTheme(AppThemeColor()),
+      dark: _buildTheme(AppDarkThemeColor()),
     );
   }
 
-  static AppTheme _buildDarkTheme() {
-    final themeColor = AppDarkThemeColor();
-    final textTheme = _createTextTheme(themeColor);
+  static AppTheme _buildTheme(ThemeColor themeColor) {
+    final typography = _createTypographyTheme();
+    final textTheme = typography.create(themeColor);
 
-    return AppTheme.factory(
-      screenTheme: _createScreenTheme(
-        screenFormTheme: AppScreenFormDarkTheme(textTheme),
-        mainPageFormTheme: AppMainPageFormDarkTheme(textTheme),
+    return AppTheme.create(
+      AppThemeConfig(
+        designSystem: AppDesignSystem(
+          name: themeColor.brightness.name,
+          colors: themeColor,
+          screenTheme: AppScreenThemes.create(textTheme),
+          typography: typography,
+          textTheme: textTheme,
+        ),
       ),
-      appTextTheme: textTheme,
-      themeColor: themeColor,
-      targetPlatform: _getTargetPlatform(),
     );
   }
 
-  static AppTextTheme _createTextTheme(ThemeColor themeColor) {
-    return AppTextTheme.create(
-      themeColor,
-      wrapper: (style) {
-        /// You can use Google Fonts to apply font family
-        /// e.g., return GoogleFonts.poppins(textStyle: style);
-        return style;
-      },
-    ).let(
-      (textTheme) => textTheme.copyWithTypography(
+  static AppTypographyTheme _createTypographyTheme() {
+    return AppTypographyTheme(
+      override: (textTheme) => textTheme.copyWithTypography(
         inputTitle: textTheme.bodyMedium,
         buttonText: textTheme.bodyMedium?.copyWith(
           fontSize: 15,
@@ -62,19 +44,5 @@ class MainAppTheme {
         ),
       ),
     );
-  }
-
-  static ScreenTheme _createScreenTheme({
-    required dynamic screenFormTheme,
-    required dynamic mainPageFormTheme,
-  }) {
-    return ScreenTheme(
-      screenFormTheme: screenFormTheme,
-      mainPageFormTheme: mainPageFormTheme,
-    );
-  }
-
-  static TargetPlatform? _getTargetPlatform() {
-    return kIsWeb ? null : TargetPlatform.iOS;
   }
 }

--- a/apps/main/lib/presentation/theme/theme_color.dart
+++ b/apps/main/lib/presentation/theme/theme_color.dart
@@ -1,30 +1,56 @@
 import 'package:core/core.dart';
 import 'package:flutter/material.dart';
 
+class AppPalette {
+  AppPalette._();
+
+  static const primary = Color(0xFF3B82F6);
+  static const secondary = Color(0xFFEFF6FF);
+  static const lightScaffold = Color(0xFFF3F4F6);
+  static const lightLabel = Color(0xFF8E8E93);
+  static const darkSurface = Color(0xFF111827);
+  static const darkCard = Color(0xFF1F2937);
+  static const darkScaffold = Color(0xFF0F172A);
+  static const darkBorder = Color(0xFF374151);
+  static const darkLabel = Color(0xFFD1D5DB);
+}
+
 class AppThemeColor extends ThemeColor {
   AppThemeColor({
-    super.primary = const Color(0xFF3B82F6),
-    super.secondary = const Color(0xFFEFF6FF),
+    super.primary = AppPalette.primary,
+    super.secondary = AppPalette.secondary,
     super.appbarBackgroundColor = Colors.white,
     super.appbarForegroundColor = Colors.black,
-    super.scaffoldBackgroundColor = const Color(0xffF3F4F6),
+    super.scaffoldBackgroundColor = AppPalette.lightScaffold,
     super.brightness = Brightness.light,
     super.elevatedBtnForegroundColor = Colors.white,
     super.schemeAction = Colors.grey,
-    super.outlineButtonColor = const Color(0xff3B82F6),
-    super.labelText = const Color(0xff8E8E93),
+    super.outlineButtonColor = AppPalette.primary,
+    super.labelText = AppPalette.lightLabel,
   });
 }
 
 class AppDarkThemeColor extends ThemeColor {
   AppDarkThemeColor({
-    super.primary = const Color(0xFF3B82F6),
-    super.secondary = const Color(0xFFEFF6FF),
-    super.appbarForegroundColor = Colors.white60,
-    super.appbarBackgroundColor = Colors.black54,
+    super.primary = AppPalette.primary,
+    super.secondary = AppPalette.secondary,
+    super.surface = AppPalette.darkSurface,
+    super.background = AppPalette.darkScaffold,
+    super.cardBackground = AppPalette.darkCard,
+    super.canvasColor = AppPalette.darkSurface,
+    super.scaffoldBackgroundColor = AppPalette.darkScaffold,
+    super.appbarForegroundColor = Colors.white,
+    super.appbarBackgroundColor = AppPalette.darkSurface,
+    super.borderColor = AppPalette.darkBorder,
+    super.dividerColor = AppPalette.darkBorder,
     super.brightness = Brightness.dark,
+    super.elevatedBtnForegroundColor = Colors.white,
     super.schemeAction = Colors.grey,
-    super.outlineButtonColor = const Color(0xff3B82F6),
-    super.labelText = const Color(0xff8E8E93),
+    super.outlineButtonColor = AppPalette.primary,
+    super.labelText = AppPalette.darkLabel,
+    super.displayText = Colors.white,
+    super.headlineText = Colors.white,
+    super.titleText = Colors.white,
+    super.bodyText = AppPalette.darkLabel,
   });
 }

--- a/core/lib/presentation/modules/dev_mode/design_system/pages/theme_color_page.dart
+++ b/core/lib/presentation/modules/dev_mode/design_system/pages/theme_color_page.dart
@@ -10,114 +10,260 @@ class ThemeColorPage extends StatefulWidget {
 }
 
 class _ThemeColorPageState extends State<ThemeColorPage> {
-  List<Map<String, dynamic>> get themeDemo {
+  late List<_ThemeDemo> _themeDemo;
+  ScreenTheme? _screenTheme;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
     final screenTheme = context.screenTheme;
+    if (!identical(_screenTheme, screenTheme)) {
+      _screenTheme = screenTheme;
+      _themeDemo = _createThemeDemo(screenTheme);
+    }
+  }
+
+  List<_ThemeDemo> _createThemeDemo(ScreenTheme screenTheme) {
     return [
-      {
-        'name': 'Pink',
-        'light': AppTheme.factory(
+      _ThemeDemo(
+        name: 'Pink',
+        light: _createTheme(
           screenTheme: screenTheme,
-          themeColor: ThemeColor(
-            primary: const Color.fromARGB(255, 217, 98, 167),
-            secondary: const Color.fromARGB(240, 250, 230, 250),
-            appbarForegroundColor: Colors.white,
-            brightness: Brightness.light,
-            shadowColor: const Color.fromARGB(192, 246, 230, 250),
-          ),
+          name: 'Pink',
+          primary: const Color.fromARGB(255, 217, 98, 167),
+          secondary: const Color.fromARGB(240, 250, 230, 250),
+          appbarForegroundColor: Colors.white,
+          shadowColor: const Color.fromARGB(192, 246, 230, 250),
         ),
-        'dark': AppTheme.factory(
+        dark: _createTheme(
           screenTheme: screenTheme,
-          themeColor: ThemeColor(
-            primary: const Color.fromARGB(255, 93, 47, 74),
-            secondary: const Color.fromARGB(240, 250, 230, 250),
-            shadowColor: const Color.fromARGB(63, 246, 230, 250),
-            appbarForegroundColor: Colors.white,
-            brightness: Brightness.dark,
-          ),
+          name: 'Pink Dark',
+          primary: const Color.fromARGB(255, 93, 47, 74),
+          secondary: const Color.fromARGB(240, 250, 230, 250),
+          appbarForegroundColor: Colors.white,
+          shadowColor: const Color.fromARGB(63, 246, 230, 250),
+          brightness: Brightness.dark,
         ),
-      },
-      {
-        'name': 'Blue',
-        'light': AppTheme.factory(
+      ),
+      _ThemeDemo(
+        name: 'Blue',
+        light: _createTheme(
           screenTheme: screenTheme,
-          themeColor: ThemeColor(
-            primary: Colors.blue,
-            secondary: const Color.fromARGB(239, 221, 233, 251),
-            appbarForegroundColor: Colors.white,
-            brightness: Brightness.light,
-          ),
+          name: 'Blue',
+          primary: Colors.blue,
+          secondary: const Color.fromARGB(239, 221, 233, 251),
+          appbarForegroundColor: Colors.white,
         ),
-        'dark': AppTheme.factory(
+        dark: _createTheme(
           screenTheme: screenTheme,
-          themeColor: ThemeColor(
-            primary: const Color.fromARGB(255, 22, 43, 116),
-            secondary: const Color.fromARGB(239, 221, 233, 251),
-            appbarForegroundColor: Colors.white,
-            brightness: Brightness.dark,
-          ),
+          name: 'Blue Dark',
+          primary: const Color.fromARGB(255, 22, 43, 116),
+          secondary: const Color.fromARGB(239, 221, 233, 251),
+          appbarForegroundColor: Colors.white,
+          brightness: Brightness.dark,
         ),
-      },
-      {
-        'name': 'Cyan Accent',
-        'light': AppTheme.factory(
+      ),
+      _ThemeDemo(
+        name: 'Cyan Accent',
+        light: _createTheme(
           screenTheme: screenTheme,
-          themeColor: ThemeColor(
-            primary: Colors.cyanAccent,
-            secondary: const Color.fromARGB(239, 221, 233, 251),
-            appbarForegroundColor: Colors.black,
-            brightness: Brightness.light,
-          ),
+          name: 'Cyan Accent',
+          primary: Colors.cyanAccent,
+          secondary: const Color.fromARGB(239, 221, 233, 251),
+          appbarForegroundColor: Colors.black,
         ),
-        'dark': AppTheme.factory(
+        dark: _createTheme(
           screenTheme: screenTheme,
-          themeColor: ThemeColor(
-            primary: const Color.fromARGB(255, 10, 99, 99),
-            secondary: const Color.fromARGB(239, 221, 233, 251),
-            appbarForegroundColor: Colors.white,
-            brightness: Brightness.dark,
-          ),
+          name: 'Cyan Accent Dark',
+          primary: const Color.fromARGB(255, 10, 99, 99),
+          secondary: const Color.fromARGB(239, 221, 233, 251),
+          appbarForegroundColor: Colors.white,
+          brightness: Brightness.dark,
         ),
-      },
-      {
-        'name': 'Red',
-        'light': AppTheme.factory(
+      ),
+      _ThemeDemo(
+        name: 'Red',
+        light: _createTheme(
           screenTheme: screenTheme,
-          themeColor: ThemeColor(
-            primary: Colors.red,
-            secondary: const Color.fromARGB(239, 221, 233, 251),
-            appbarForegroundColor: Colors.black,
-            brightness: Brightness.light,
-          ),
+          name: 'Red',
+          primary: Colors.red,
+          secondary: const Color.fromARGB(239, 221, 233, 251),
+          appbarForegroundColor: Colors.black,
         ),
-        'dark': AppTheme.factory(
+        dark: _createTheme(
           screenTheme: screenTheme,
-          themeColor: ThemeColor(
-            primary: const Color.fromARGB(255, 125, 34, 28),
-            secondary: const Color.fromARGB(239, 221, 233, 251),
-            appbarForegroundColor: Colors.white,
-            brightness: Brightness.dark,
-          ),
+          name: 'Red Dark',
+          primary: const Color.fromARGB(255, 125, 34, 28),
+          secondary: const Color.fromARGB(239, 221, 233, 251),
+          appbarForegroundColor: Colors.white,
+          brightness: Brightness.dark,
         ),
-      },
+      ),
+    ];
+  }
+
+  AppTheme _createTheme({
+    required ScreenTheme screenTheme,
+    required String name,
+    required Color primary,
+    required Color secondary,
+    required Color appbarForegroundColor,
+    Brightness brightness = Brightness.light,
+    Color? shadowColor,
+  }) {
+    final themeColor = ThemeColor(
+      primary: primary,
+      secondary: secondary,
+      appbarForegroundColor: appbarForegroundColor,
+      brightness: brightness,
+      shadowColor: shadowColor,
+    );
+    return AppTheme.create(
+      AppThemeConfig(
+        designSystem: AppDesignSystem(
+          name: name,
+          colors: themeColor,
+          screenTheme: screenTheme,
+        ),
+      ),
+    );
+  }
+
+  List<_ColorSwatch> _themeColorSwatches(ThemeColor themeColor) {
+    return [
+      _ColorSwatch(color: themeColor.primary, name: 'primary'),
+      _ColorSwatch(color: themeColor.primaryVariant, name: 'primaryVariant'),
+      _ColorSwatch(color: themeColor.secondary, name: 'secondary'),
+      _ColorSwatch(
+        color: themeColor.secondaryVariant,
+        name: 'secondaryVariant',
+      ),
+      _ColorSwatch(color: themeColor.surface, name: 'surface'),
+      _ColorSwatch(color: themeColor.background, name: 'background'),
+      _ColorSwatch(color: themeColor.error, name: 'error'),
+      _ColorSwatch(color: themeColor.onPrimary, name: 'onPrimary'),
+      _ColorSwatch(color: themeColor.onSecondary, name: 'onSecondary'),
+      _ColorSwatch(color: themeColor.onBackground, name: 'onBackground'),
+      _ColorSwatch(color: themeColor.onSurface, name: 'onSurface'),
+      _ColorSwatch(color: themeColor.onError, name: 'onError'),
+      _ColorSwatch(color: themeColor.themePrimary, name: 'themePrimary'),
+      _ColorSwatch(
+        color: themeColor.appbarForegroundColor,
+        name: 'appbarForegroundColor',
+      ),
+      _ColorSwatch(color: themeColor.schemeAction, name: 'schemeAction'),
+      _ColorSwatch(color: themeColor.cardBackground, name: 'cardBackground'),
+      _ColorSwatch(
+        color: themeColor.scaffoldBackgroundColor,
+        name: 'scaffoldBackgroundColor',
+      ),
+      _ColorSwatch(color: themeColor.disableColor, name: 'disableColor'),
+      _ColorSwatch(color: themeColor.dividerColor, name: 'dividerColor'),
+      _ColorSwatch(color: themeColor.borderColor, name: 'borderColor'),
+      _ColorSwatch(
+        color: themeColor.unselectedLabelColor,
+        name: 'unselectedLabelColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.selectedLabelColor,
+        name: 'selectedLabelColor',
+      ),
+      _ColorSwatch(color: themeColor.selected, name: 'selected'),
+      _ColorSwatch(color: themeColor.splashColor, name: 'splashColor'),
+      _ColorSwatch(color: themeColor.shadowColor, name: 'shadowColor'),
+      _ColorSwatch(color: themeColor.textButtonColor, name: 'textButtonColor'),
+      _ColorSwatch(
+        color: themeColor.textButtonDisableColor,
+        name: 'textButtonDisableColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.elevatedBtnForegroundColor,
+        name: 'elevatedBtnForegroundColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.elevatedBtnBackgroundColor,
+        name: 'elevatedBtnBackgroundColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.elevatedBtnForegroundDisableColor,
+        name: 'elevatedBtnForegroundDisableColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.elevatedBtnBackgroundDisableColor,
+        name: 'elevatedBtnBackgroundDisableColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.outlineButtonColor,
+        name: 'outlineButtonColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.outlineButtonBackgroundColor,
+        name: 'outlineButtonBackgroundColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.outlineButtonDisableColor,
+        name: 'outlineButtonDisableColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.checkboxCheckColor,
+        name: 'checkboxCheckColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.checkboxActiveColor,
+        name: 'checkboxActiveColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.checkboxBorderColor,
+        name: 'checkboxBorderColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.checkboxDisabledColor,
+        name: 'checkboxDisabledColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.chipBackgroundColor,
+        name: 'chipBackgroundColor',
+      ),
+      _ColorSwatch(color: themeColor.chipBorderColor, name: 'chipBorderColor'),
+      _ColorSwatch(color: themeColor.chipLabelColor, name: 'chipLabelColor'),
+      _ColorSwatch(
+        color: themeColor.chipSelectedColor,
+        name: 'chipSelectedColor',
+      ),
+      _ColorSwatch(
+        color: themeColor.chipDisabledColor,
+        name: 'chipDisabledColor',
+      ),
+      _ColorSwatch(color: themeColor.deleteIconColor, name: 'deleteIconColor'),
+      _ColorSwatch(color: themeColor.displayText, name: 'displayText'),
+      _ColorSwatch(color: themeColor.headlineText, name: 'headlineText'),
+      _ColorSwatch(color: themeColor.titleText, name: 'titleText'),
+      _ColorSwatch(color: themeColor.bodyText, name: 'bodyText'),
+      _ColorSwatch(color: themeColor.labelText, name: 'labelText'),
+      _ColorSwatch(color: themeColor.warningText, name: 'warningText'),
+      _ColorSwatch(color: themeColor.hyperLink, name: 'hyperLink'),
     ];
   }
 
   @override
   Widget build(BuildContext context) {
+    final themeColor = context.themeColor;
+    final colorSwatches = _themeColorSwatches(themeColor);
+
     return ListView(
       padding: const EdgeInsets.all(
         16,
       ).copyWith(bottom: MediaQuery.of(context).padding.bottom + 16),
       children: <Widget>[
-        ...themeDemo.map((e) {
+        ..._themeDemo.map((demo) {
           return Theme(
-            data: e['light'].theme,
+            data: demo.light.theme,
             child: OutlinedButton(
-              child: Text('${e['name']} Theme'),
+              child: Text('${demo.name} Theme'),
               onPressed: () {
                 context.read<AppGlobalBloc>().updateTheme(
-                  lightTheme: e['light'],
-                  darkTheme: e['dark'],
+                  lightTheme: demo.light,
+                  darkTheme: demo.dark,
                 );
               },
             ),
@@ -133,129 +279,17 @@ class _ThemeColorPageState extends State<ThemeColorPage> {
           mainAxisSpacing: 0.0,
           crossAxisSpacing: 0.0,
           children: [
-            ...[
-              {'color': themeColor.primary, 'name': 'primary'},
-              {'color': themeColor.primaryVariant, 'name': 'primaryVariant'},
-              {'color': themeColor.secondary, 'name': 'secondary'},
-              {
-                'color': themeColor.secondaryVariant,
-                'name': 'secondaryVariant',
-              },
-              {'color': themeColor.surface, 'name': 'surface'},
-              {'color': themeColor.background, 'name': 'background'},
-              {'color': themeColor.error, 'name': 'error'},
-              {'color': themeColor.onPrimary, 'name': 'onPrimary'},
-              {'color': themeColor.onSecondary, 'name': 'onSecondary'},
-              {'color': themeColor.onBackground, 'name': 'onBackground'},
-              {'color': themeColor.onSurface, 'name': 'onSurface'},
-              {'color': themeColor.onError, 'name': 'onError'},
-              {'color': themeColor.themePrimary, 'name': 'themePrimary'},
-              {
-                'color': themeColor.appbarForegroundColor,
-                'name': 'appbarForegroundColor',
-              },
-              {'color': themeColor.schemeAction, 'name': 'schemeAction'},
-              {'color': themeColor.cardBackground, 'name': 'cardBackground'},
-              {
-                'color': themeColor.scaffoldBackgroundColor,
-                'name': 'scaffoldBackgroundColor',
-              },
-              {'color': themeColor.disableColor, 'name': 'disableColor'},
-              {'color': themeColor.dividerColor, 'name': 'dividerColor'},
-              {'color': themeColor.borderColor, 'name': 'borderColor'},
-              {
-                'color': themeColor.unselectedLabelColor,
-                'name': 'unselectedLabelColor',
-              },
-              {
-                'color': themeColor.selectedLabelColor,
-                'name': 'selectedLabelColor',
-              },
-              {'color': themeColor.selected, 'name': 'selected'},
-              {'color': themeColor.splashColor, 'name': 'splashColor'},
-              {'color': themeColor.shadowColor, 'name': 'shadowColor'},
-              {'color': themeColor.textButtonColor, 'name': 'textButtonColor'},
-              {
-                'color': themeColor.textButtonDisableColor,
-                'name': 'textButtonDisableColor',
-              },
-              {
-                'color': themeColor.elevatedBtnForegroundColor,
-                'name': 'elevatedBtnForegroundColor',
-              },
-              {
-                'color': themeColor.elevatedBtnBackgroundColor,
-                'name': 'elevatedBtnBackgroundColor',
-              },
-              {
-                'color': themeColor.elevatedBtnForegroundDisableColor,
-                'name': 'elevatedBtnForegroundDisableColor',
-              },
-              {
-                'color': themeColor.elevatedBtnBackgroundDisableColor,
-                'name': 'elevatedBtnBackgroundDisableColor',
-              },
-              {
-                'color': themeColor.outlineButtonColor,
-                'name': 'outlineButtonColor',
-              },
-              {
-                'color': themeColor.outlineButtonBackgroundColor,
-                'name': 'outlineButtonBackgroundColor',
-              },
-              {
-                'color': themeColor.outlineButtonDisableColor,
-                'name': 'outlineButtonDisableColor',
-              },
-              {
-                'color': themeColor.checkboxCheckColor,
-                'name': 'checkboxCheckColor',
-              },
-              {
-                'color': themeColor.checkboxActiveColor,
-                'name': 'checkboxActiveColor',
-              },
-              {
-                'color': themeColor.checkboxBorderColor,
-                'name': 'checkboxBorderColor',
-              },
-              {
-                'color': themeColor.checkboxDisabledColor,
-                'name': 'checkboxDisabledColor',
-              },
-              {
-                'color': themeColor.chipBackgroundColor,
-                'name': 'chipBackgroundColor',
-              },
-              {'color': themeColor.chipBorderColor, 'name': 'chipBorderColor'},
-              {'color': themeColor.chipLabelColor, 'name': 'chipLabelColor'},
-              {
-                'color': themeColor.chipSelectedColor,
-                'name': 'chipSelectedColor',
-              },
-              {
-                'color': themeColor.chipDisabledColor,
-                'name': 'chipDisabledColor',
-              },
-              {'color': themeColor.deleteIconColor, 'name': 'deleteIconColor'},
-              {'color': themeColor.displayText, 'name': 'displayText'},
-              {'color': themeColor.headlineText, 'name': 'headlineText'},
-              {'color': themeColor.titleText, 'name': 'titleText'},
-              {'color': themeColor.bodyText, 'name': 'bodyText'},
-              {'color': themeColor.labelText, 'name': 'labelText'},
-              {'color': themeColor.warningText, 'name': 'warningText'},
-              {'color': themeColor.hyperLink, 'name': 'hyperLink'},
-            ].map(
-              (e) => InkWell(
+            ...colorSwatches.map(
+              (swatch) => InkWell(
                 onTap: () {
-                  showToast(context, '${e['name']} - ${e['color']}');
+                  showToast(context, '${swatch.name} - ${swatch.color}');
                 },
                 child: Container(
                   padding: const EdgeInsets.all(2),
                   alignment: Alignment.center,
-                  color: e['color'] as Color?,
+                  color: swatch.color,
                   child: Text(
-                    e['name'] as String,
+                    swatch.name,
                     textAlign: TextAlign.center,
                     style: context.textTheme.bodyLarge,
                   ),
@@ -295,4 +329,23 @@ class _ThemeColorPageState extends State<ThemeColorPage> {
       ].insertSeparator((index) => const SizedBox(height: 16)),
     );
   }
+}
+
+class _ThemeDemo {
+  final String name;
+  final AppTheme light;
+  final AppTheme dark;
+
+  const _ThemeDemo({
+    required this.name,
+    required this.light,
+    required this.dark,
+  });
+}
+
+class _ColorSwatch {
+  final Color? color;
+  final String name;
+
+  const _ColorSwatch({required this.color, required this.name});
 }

--- a/plugins/fl_theme/example/README.md
+++ b/plugins/fl_theme/example/README.md
@@ -1,16 +1,53 @@
-# fl_theme_example
+# fl_theme JSON playground
 
-Demonstrates how to use the fl_theme plugin.
+This example is a web-friendly playground for `fl_theme` theme configuration.
 
-## Getting Started
+It demonstrates:
 
-This project is a starting point for a Flutter application.
+- building `AppTheme` from `ThemeJsonConfig`
+- previewing FlexColorScheme-backed Material component themes
+- editing the full JSON v1 schema for colors, typography, decoration, components, and screen chrome
+- exporting/importing the same JSON used by the runtime design-system factory
+- preview-only device frames that do not change exported theme JSON
 
-A few resources to get you started if this is your first Flutter project:
+## Run
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+```bash
+flutter run -d chrome
+```
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+or:
+
+```bash
+flutter run -d web-server --web-port 3000
+```
+
+## JSON flow
+
+```dart
+final config = ThemeJsonConfig.decode(jsonSource);
+final designSystem = AppDesignSystem.fromJsonConfig(config);
+final appTheme = AppTheme.create(
+  AppThemeConfig(designSystem: designSystem),
+);
+```
+
+The JSON panel accepts `#RRGGBB` and `#AARRGGBB` colors. Invalid JSON or invalid token values stay in the editor and show the parser error, so the current preview theme is not lost.
+
+## Preview options
+
+The device-frame controls are example-only. They wrap the preview screen with `device_frame` to show safe areas, platform density, and common device sizes, but they are intentionally not included in `ThemeJsonConfig.encode()`.
+
+## Smoke checklist
+
+When changing the playground, run a browser smoke check:
+
+- open the playground on web
+- switch presets and confirm controls update
+- change color, radius, typography, component, and screen controls
+- apply valid JSON and verify the title/preview update
+- apply invalid JSON and verify an error appears without crashing
+- copy or restore the current theme JSON
+- toggle device frame and switch devices/orientation
+- resize to narrow and wide layouts
+- check the browser console for warnings/errors

--- a/plugins/fl_theme/example/lib/main.dart
+++ b/plugins/fl_theme/example/lib/main.dart
@@ -1,28 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'src/theme_playground_app.dart';
+
 void main() {
-  runApp(const MyApp());
-}
-
-class MyApp extends StatefulWidget {
-  const MyApp({super.key});
-
-  @override
-  State<MyApp> createState() => _MyAppState();
-}
-
-class _MyAppState extends State<MyApp> {
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Plugin example app'),
-        ),
-        body: const Center(
-          child: Text('FL_Theme'),
-        ),
-      ),
-    );
-  }
+  runApp(const ThemePlaygroundApp());
 }

--- a/plugins/fl_theme/example/lib/src/playground/theme_editor_panel.dart
+++ b/plugins/fl_theme/example/lib/src/playground/theme_editor_panel.dart
@@ -1,0 +1,663 @@
+import 'package:fl_theme/fl_theme.dart';
+import 'package:flutter/material.dart';
+
+import 'theme_presets.dart';
+import 'theme_preview_options.dart';
+
+class ThemeEditorPanel extends StatelessWidget {
+  final ThemeJsonConfig config;
+  final ThemePreviewOptions previewOptions;
+  final ValueChanged<ThemeJsonConfig> onChanged;
+  final ValueChanged<ThemePreviewOptions> onPreviewOptionsChanged;
+  final ValueChanged<ThemeJsonConfig> onPresetSelected;
+
+  const ThemeEditorPanel({
+    super.key,
+    required this.config,
+    required this.previewOptions,
+    required this.onChanged,
+    required this.onPreviewOptionsChanged,
+    required this.onPresetSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final spacing = context.decorationTheme.spaceMd;
+
+    return ListView(
+      key: const ValueKey('theme_controls_list'),
+      children: [
+        Text('Theme controls', style: Theme.of(context).textTheme.titleMedium),
+        SizedBox(height: spacing),
+        _Section(
+          title: 'Preset and mode',
+          children: [
+            _PresetDropdown(
+              value: _presetLabel,
+              onChanged: (value) {
+                final preset =
+                    themePresets.firstWhere((it) => it.label == value);
+                onPresetSelected(preset.config);
+              },
+            ),
+            _TextEditor(
+              label: 'Theme name',
+              value: config.name,
+              onSubmitted: (value) => onChanged(config.copyWith(name: value)),
+            ),
+            _ChoiceEditor<Brightness>(
+              label: 'Mode',
+              value: config.mode,
+              values: Brightness.values,
+              labelBuilder: (value) => value.name,
+              onChanged: (value) => onChanged(config.copyWith(mode: value)),
+            ),
+            SwitchListTile(
+              value: config.useMaterial3,
+              title: const Text('Use Material 3'),
+              contentPadding: EdgeInsets.zero,
+              onChanged: (value) =>
+                  onChanged(config.copyWith(useMaterial3: value)),
+            ),
+            _TextEditor(
+              label: 'Font family',
+              value: config.fontFamily ?? '',
+              helperText: 'Leave empty to use the platform default.',
+              onSubmitted: (value) => onChanged(
+                config.copyWith(
+                  fontFamily: value.trim().isEmpty ? null : value.trim(),
+                  includeFontFamily: true,
+                ),
+              ),
+            ),
+          ],
+        ),
+        _Section(
+          title: 'Colors',
+          children: [
+            _ColorEditor(
+              label: 'Primary',
+              color: config.colors.primary,
+              onChanged: (color) => onChanged(
+                config.copyWith(colors: config.colors.copyWith(primary: color)),
+              ),
+            ),
+            _ColorEditor(
+              label: 'Secondary',
+              color: config.colors.secondary,
+              onChanged: (color) => onChanged(
+                config.copyWith(
+                    colors: config.colors.copyWith(secondary: color)),
+              ),
+            ),
+            _ColorEditor(
+              label: 'Surface',
+              color: config.colors.surface,
+              onChanged: (color) => onChanged(
+                config.copyWith(colors: config.colors.copyWith(surface: color)),
+              ),
+            ),
+            _ColorEditor(
+              label: 'Background',
+              color: config.colors.background,
+              onChanged: (color) => onChanged(
+                config.copyWith(
+                    colors: config.colors.copyWith(background: color)),
+              ),
+            ),
+            _ColorEditor(
+              label: 'Error',
+              color: config.colors.error,
+              onChanged: (color) => onChanged(
+                config.copyWith(colors: config.colors.copyWith(error: color)),
+              ),
+            ),
+            _ColorEditor(
+              label: 'App bar background',
+              color: config.colors.appBarBackground,
+              onChanged: (color) => onChanged(
+                config.copyWith(
+                  colors: config.colors.copyWith(appBarBackground: color),
+                ),
+              ),
+            ),
+            _ColorEditor(
+              label: 'App bar foreground',
+              color: config.colors.appBarForeground,
+              onChanged: (color) => onChanged(
+                config.copyWith(
+                  colors: config.colors.copyWith(appBarForeground: color),
+                ),
+              ),
+            ),
+          ],
+        ),
+        _Section(
+          title: 'Decoration',
+          children: [
+            _SliderEditor(
+              label: 'Base radius',
+              value: config.decoration.radius,
+              min: 0,
+              max: 32,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  decoration: config.decoration.copyWith(radius: value),
+                ),
+              ),
+            ),
+            _SliderEditor(
+              label: 'Button radius',
+              value: config.decoration.buttonRadius,
+              min: 0,
+              max: 32,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  decoration: config.decoration.copyWith(buttonRadius: value),
+                ),
+              ),
+            ),
+            _SliderEditor(
+              label: 'Input radius',
+              value: config.decoration.inputRadius,
+              min: 0,
+              max: 32,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  decoration: config.decoration.copyWith(inputRadius: value),
+                ),
+              ),
+            ),
+            _SliderEditor(
+              label: 'Chip radius',
+              value: config.decoration.chipRadius,
+              min: 0,
+              max: 40,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  decoration: config.decoration.copyWith(chipRadius: value),
+                ),
+              ),
+            ),
+            _SliderEditor(
+              label: 'Screen padding',
+              value: config.decoration.screenPadding,
+              min: 8,
+              max: 40,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  decoration: config.decoration.copyWith(screenPadding: value),
+                ),
+              ),
+            ),
+          ],
+        ),
+        _Section(
+          title: 'Typography',
+          children: [
+            _SliderEditor(
+              label: 'Button font size',
+              value: config.typography.buttonFontSize,
+              min: 12,
+              max: 24,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  typography: config.typography.copyWith(buttonFontSize: value),
+                ),
+              ),
+            ),
+            _ChoiceEditor<int>(
+              label: 'Button font weight',
+              value: config.typography.buttonFontWeight,
+              values: const [100, 200, 300, 400, 500, 600, 700, 800, 900],
+              labelBuilder: (value) => value.toString(),
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  typography:
+                      config.typography.copyWith(buttonFontWeight: value),
+                ),
+              ),
+            ),
+            _SliderEditor(
+              label: 'Body font size',
+              value: config.typography.bodyFontSize,
+              min: 12,
+              max: 22,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  typography: config.typography.copyWith(bodyFontSize: value),
+                ),
+              ),
+            ),
+          ],
+        ),
+        _Section(
+          title: 'Components',
+          children: [
+            _SwitchEditor(
+              label: 'Filled inputs',
+              value: config.components.inputFilled,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  components: config.components.copyWith(inputFilled: value),
+                ),
+              ),
+            ),
+            _SwitchEditor(
+              label: 'Center app bar titles',
+              value: config.components.appBarCenterTitle,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  components: config.components.copyWith(
+                    appBarCenterTitle: value,
+                  ),
+                ),
+              ),
+            ),
+            _SwitchEditor(
+              label: 'Show chip checkmarks',
+              value: config.components.chipShowCheckmark,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  components: config.components.copyWith(
+                    chipShowCheckmark: value,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+        _Section(
+          title: 'Screen chrome',
+          children: [
+            _SwitchEditor(
+              label: 'Show header image',
+              value: config.screen.showHeaderImage,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  screen: config.screen.copyWith(showHeaderImage: value),
+                ),
+              ),
+            ),
+            _SwitchEditor(
+              label: 'Bottom border radius',
+              value: config.screen.hasBottomBorderRadius,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  screen: config.screen.copyWith(hasBottomBorderRadius: value),
+                ),
+              ),
+            ),
+            _SwitchEditor(
+              label: 'App bar divider',
+              value: config.screen.showAppbarDivider,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                  screen: config.screen.copyWith(showAppbarDivider: value),
+                ),
+              ),
+            ),
+            _SwitchEditor(
+              label: 'Center screen titles',
+              value: config.screen.centerTitle,
+              onChanged: (value) => onChanged(
+                config.copyWith(
+                    screen: config.screen.copyWith(centerTitle: value)),
+              ),
+            ),
+          ],
+        ),
+        _Section(
+          title: 'Preview only',
+          children: [
+            _SwitchEditor(
+              label: 'Show device frame',
+              value: previewOptions.showDeviceFrame,
+              onChanged: (value) => onPreviewOptionsChanged(
+                previewOptions.copyWith(showDeviceFrame: value),
+              ),
+            ),
+            _ChoiceEditor<ThemePreviewDevice>(
+              label: 'Device',
+              value: previewOptions.selectedDevice,
+              values: themePreviewDevices,
+              labelBuilder: (device) => device.label,
+              onChanged: (device) => onPreviewOptionsChanged(
+                previewOptions.copyWith(selectedDevice: device),
+              ),
+            ),
+            _ChoiceEditor<Orientation>(
+              label: 'Orientation',
+              value: previewOptions.orientation,
+              values: Orientation.values,
+              labelBuilder: (value) => value.name,
+              onChanged: (value) => onPreviewOptionsChanged(
+                previewOptions.copyWith(orientation: value),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  String get _presetLabel {
+    return themePresets
+        .firstWhere(
+          (preset) => preset.config.name == config.name,
+          orElse: () => themePresets.first,
+        )
+        .label;
+  }
+}
+
+class _Section extends StatelessWidget {
+  final String title;
+  final List<Widget> children;
+
+  const _Section({required this.title, required this.children});
+
+  @override
+  Widget build(BuildContext context) {
+    final decoration = context.decorationTheme;
+    return Padding(
+      padding: EdgeInsets.only(top: decoration.spaceLg),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(title, style: Theme.of(context).textTheme.titleSmall),
+          SizedBox(height: decoration.spaceSm),
+          ...children.insertSpacing(SizedBox(height: decoration.spaceSm)),
+        ],
+      ),
+    );
+  }
+}
+
+class _PresetDropdown extends StatelessWidget {
+  final String value;
+  final ValueChanged<String> onChanged;
+
+  const _PresetDropdown({required this.value, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return InputDecorator(
+      decoration: const InputDecoration(
+        labelText: 'Preset',
+        border: OutlineInputBorder(),
+      ),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<String>(
+          value: value,
+          isExpanded: true,
+          items: themePresets
+              .map(
+                (preset) => DropdownMenuItem(
+                  value: preset.label,
+                  child: Text(preset.label),
+                ),
+              )
+              .toList(),
+          onChanged: (value) {
+            if (value != null) {
+              onChanged(value);
+            }
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _ChoiceEditor<T> extends StatelessWidget {
+  final String label;
+  final T value;
+  final List<T> values;
+  final String Function(T value) labelBuilder;
+  final ValueChanged<T> onChanged;
+
+  const _ChoiceEditor({
+    required this.label,
+    required this.value,
+    required this.values,
+    required this.labelBuilder,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InputDecorator(
+      decoration:
+          InputDecoration(labelText: label, border: const OutlineInputBorder()),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<T>(
+          value: value,
+          isExpanded: true,
+          items: values
+              .map(
+                (item) => DropdownMenuItem(
+                    value: item, child: Text(labelBuilder(item))),
+              )
+              .toList(),
+          onChanged: (value) {
+            if (value != null) {
+              onChanged(value);
+            }
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _SwitchEditor extends StatelessWidget {
+  final String label;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  const _SwitchEditor({
+    required this.label,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      value: value,
+      title: Text(label),
+      contentPadding: EdgeInsets.zero,
+      onChanged: onChanged,
+    );
+  }
+}
+
+class _TextEditor extends StatefulWidget {
+  final String label;
+  final String value;
+  final String? helperText;
+  final ValueChanged<String> onSubmitted;
+
+  const _TextEditor({
+    required this.label,
+    required this.value,
+    required this.onSubmitted,
+    this.helperText,
+  });
+
+  @override
+  State<_TextEditor> createState() => _TextEditorState();
+}
+
+class _TextEditorState extends State<_TextEditor> {
+  late final TextEditingController controller;
+  late final FocusNode focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = TextEditingController(text: widget.value);
+    focusNode = FocusNode();
+  }
+
+  @override
+  void didUpdateWidget(covariant _TextEditor oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!focusNode.hasFocus && widget.value != controller.text) {
+      controller.text = widget.value;
+    }
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: controller,
+      focusNode: focusNode,
+      decoration: InputDecoration(
+        labelText: widget.label,
+        helperText: widget.helperText,
+        border: const OutlineInputBorder(),
+      ),
+      textInputAction: TextInputAction.done,
+      onFieldSubmitted: widget.onSubmitted,
+    );
+  }
+}
+
+class _ColorEditor extends StatefulWidget {
+  final String label;
+  final Color color;
+  final ValueChanged<Color> onChanged;
+
+  const _ColorEditor({
+    required this.label,
+    required this.color,
+    required this.onChanged,
+  });
+
+  @override
+  State<_ColorEditor> createState() => _ColorEditorState();
+}
+
+class _ColorEditorState extends State<_ColorEditor> {
+  late final TextEditingController controller;
+  late final FocusNode focusNode;
+  String? error;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = TextEditingController(text: themeColorToHex(widget.color));
+    focusNode = FocusNode();
+  }
+
+  @override
+  void didUpdateWidget(covariant _ColorEditor oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final nextText = themeColorToHex(widget.color);
+    if (!focusNode.hasFocus && nextText != controller.text) {
+      controller.text = nextText;
+      error = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      key: ValueKey('color_${widget.label}'),
+      controller: controller,
+      focusNode: focusNode,
+      decoration: InputDecoration(
+        labelText: widget.label,
+        helperText: 'Use #RRGGBB or #AARRGGBB.',
+        errorText: error,
+        border: const OutlineInputBorder(),
+        prefixIcon: Padding(
+          padding: const EdgeInsets.all(12),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: widget.color,
+              borderRadius: BorderRadius.circular(4),
+              border: Border.all(color: Theme.of(context).dividerColor),
+            ),
+            child: const SizedBox(width: 20, height: 20),
+          ),
+        ),
+      ),
+      textInputAction: TextInputAction.done,
+      onFieldSubmitted: _submit,
+    );
+  }
+
+  void _submit(String value) {
+    try {
+      final color = themeColorFromHex(value, path: widget.label);
+      setState(() => error = null);
+      widget.onChanged(color);
+    } on FormatException catch (exception) {
+      setState(() => error = exception.message);
+    }
+  }
+}
+
+class _SliderEditor extends StatelessWidget {
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+  final ValueChanged<double> onChanged;
+
+  const _SliderEditor({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('$label: ${value.toStringAsFixed(0)}'),
+        Slider(
+          value: value.clamp(min, max),
+          min: min,
+          max: max,
+          divisions: (max - min).round(),
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
+extension on List<Widget> {
+  List<Widget> insertSpacing(Widget separator) {
+    if (isEmpty) {
+      return this;
+    }
+    return [
+      for (var index = 0; index < length; index++) ...[
+        if (index != 0) separator,
+        this[index],
+      ],
+    ];
+  }
+}

--- a/plugins/fl_theme/example/lib/src/playground/theme_json_panel.dart
+++ b/plugins/fl_theme/example/lib/src/playground/theme_json_panel.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+class ThemeJsonPanel extends StatelessWidget {
+  final TextEditingController controller;
+  final String? error;
+  final VoidCallback onApply;
+  final VoidCallback onFormat;
+  final VoidCallback onRestore;
+  final VoidCallback onCopy;
+
+  const ThemeJsonPanel({
+    super.key,
+    required this.controller,
+    required this.error,
+    required this.onApply,
+    required this.onFormat,
+    required this.onRestore,
+    required this.onCopy,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            Text('JSON config', style: Theme.of(context).textTheme.titleMedium),
+            TextButton(
+                onPressed: onRestore, child: const Text('Restore current')),
+            TextButton(onPressed: onFormat, child: const Text('Format editor')),
+            TextButton(onPressed: onCopy, child: const Text('Copy current')),
+            FilledButton(onPressed: onApply, child: const Text('Apply JSON')),
+          ],
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          'Portable theme JSON only. Colors accept #RRGGBB or #AARRGGBB; '
+          'device-frame preview settings are not exported.',
+        ),
+        const SizedBox(height: 8),
+        Expanded(
+          child: TextField(
+            key: const ValueKey('theme_json_field'),
+            controller: controller,
+            expands: false,
+            maxLines: null,
+            minLines: null,
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+            decoration: InputDecoration(
+              border: const OutlineInputBorder(),
+              errorText: error,
+            ),
+            textAlign: TextAlign.start,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/plugins/fl_theme/example/lib/src/playground/theme_playground_screen.dart
+++ b/plugins/fl_theme/example/lib/src/playground/theme_playground_screen.dart
@@ -1,0 +1,208 @@
+import 'package:fl_theme/fl_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'theme_editor_panel.dart';
+import 'theme_json_panel.dart';
+import 'theme_presets.dart';
+import 'theme_preview_options.dart';
+import 'theme_preview_panel.dart';
+
+class ThemePlaygroundScreen extends StatefulWidget {
+  const ThemePlaygroundScreen({super.key});
+
+  @override
+  State<ThemePlaygroundScreen> createState() => _ThemePlaygroundScreenState();
+}
+
+class _ThemePlaygroundScreenState extends State<ThemePlaygroundScreen> {
+  late ThemeJsonConfig config = themePresets.first.config;
+  late AppTheme theme = _buildTheme(config);
+  ThemePreviewOptions previewOptions = ThemePreviewOptions();
+  late final TextEditingController jsonController;
+  String? jsonError;
+
+  @override
+  void initState() {
+    super.initState();
+    jsonController = TextEditingController(text: config.encode());
+  }
+
+  @override
+  void dispose() {
+    jsonController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: theme.theme,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('fl_theme JSON playground'),
+          actions: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Center(child: Text(config.name)),
+            ),
+          ],
+        ),
+        body: Builder(
+          builder: (context) {
+            final decoration = context.decorationTheme;
+            return LayoutBuilder(
+              builder: (context, constraints) {
+                final wide = constraints.maxWidth >= 1000;
+                final panelHeight = constraints.maxHeight
+                    .clamp(560.0, constraints.maxHeight)
+                    .toDouble();
+                final editor = _buildEditorCard(decoration, panelHeight);
+                final preview = _buildPreviewCard(theme.theme, decoration);
+                if (wide) {
+                  return Row(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      SizedBox(width: 420, child: editor),
+                      Expanded(child: preview),
+                    ],
+                  );
+                }
+
+                return ListView(
+                  padding: EdgeInsets.all(decoration.spaceLg),
+                  children: [
+                    SizedBox(height: panelHeight, child: editor),
+                    SizedBox(height: decoration.spaceLg),
+                    SizedBox(height: panelHeight, child: preview),
+                  ],
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEditorCard(AppDecorationTheme decoration, double panelHeight) {
+    return Card(
+      margin: EdgeInsets.all(decoration.spaceLg),
+      child: Padding(
+        padding: EdgeInsets.all(decoration.spaceLg),
+        child: DefaultTabController(
+          length: 2,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const TabBar(tabs: [Tab(text: 'Controls'), Tab(text: 'JSON')]),
+              SizedBox(height: decoration.spaceMd),
+              Flexible(
+                fit: FlexFit.loose,
+                child: SizedBox(
+                  height: panelHeight,
+                  child: TabBarView(
+                    physics: const NeverScrollableScrollPhysics(),
+                    children: [
+                      ThemeEditorPanel(
+                        config: config,
+                        previewOptions: previewOptions,
+                        onChanged: _setConfig,
+                        onPreviewOptionsChanged: _setPreviewOptions,
+                        onPresetSelected: _setConfig,
+                      ),
+                      ThemeJsonPanel(
+                        controller: jsonController,
+                        error: jsonError,
+                        onApply: _applyJson,
+                        onFormat: _formatJsonEditor,
+                        onRestore: _restoreCurrentThemeJson,
+                        onCopy: _copyJson,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPreviewCard(ThemeData theme, AppDecorationTheme decoration) {
+    return Card(
+      margin: EdgeInsets.all(decoration.spaceLg),
+      clipBehavior: Clip.antiAlias,
+      child: Theme(
+        data: theme,
+        child: ThemePreviewPanel(options: previewOptions),
+      ),
+    );
+  }
+
+  AppTheme _buildTheme(ThemeJsonConfig config) {
+    return AppTheme.create(
+      AppThemeConfig(
+        designSystem: AppDesignSystem.fromJsonConfig(config),
+      ),
+    );
+  }
+
+  void _setConfig(ThemeJsonConfig nextConfig) {
+    setState(() {
+      config = nextConfig;
+      theme = _buildTheme(config);
+      jsonError = null;
+      _syncJsonController();
+    });
+  }
+
+  void _setPreviewOptions(ThemePreviewOptions nextOptions) {
+    setState(() => previewOptions = nextOptions);
+  }
+
+  void _applyJson() {
+    try {
+      _setConfig(ThemeJsonConfig.decode(jsonController.text));
+    } on FormatException catch (error) {
+      setState(() => jsonError = error.message);
+    }
+  }
+
+  void _formatJsonEditor() {
+    try {
+      final formatted = ThemeJsonConfig.decode(jsonController.text).encode();
+      setState(() {
+        jsonController.text = formatted;
+        jsonError = null;
+      });
+    } on FormatException catch (error) {
+      setState(() => jsonError = error.message);
+    }
+  }
+
+  void _restoreCurrentThemeJson() {
+    setState(() {
+      _syncJsonController();
+      jsonError = null;
+    });
+  }
+
+  void _syncJsonController() {
+    final encoded = config.encode();
+    if (jsonController.text != encoded) {
+      jsonController.text = encoded;
+    }
+  }
+
+  Future<void> _copyJson() async {
+    await Clipboard.setData(ClipboardData(text: config.encode()));
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Current theme JSON copied')),
+    );
+  }
+}

--- a/plugins/fl_theme/example/lib/src/playground/theme_presets.dart
+++ b/plugins/fl_theme/example/lib/src/playground/theme_presets.dart
@@ -1,0 +1,157 @@
+import 'package:fl_theme/fl_theme.dart';
+import 'package:flutter/material.dart';
+
+class ThemePreset {
+  final String label;
+  final ThemeJsonConfig config;
+
+  const ThemePreset({required this.label, required this.config});
+}
+
+const themePresets = [
+  ThemePreset(
+    label: 'Ocean Blue',
+    config: ThemeJsonConfig(
+      name: 'Ocean Blue',
+      colors: ThemeJsonColor(
+        primary: Color(0xFF2563EB),
+        secondary: Color(0xFFEFF6FF),
+        surface: Colors.white,
+        background: Color(0xFFF3F4F6),
+        error: Color(0xFFB91C1C),
+        appBarBackground: Colors.white,
+        appBarForeground: Color(0xFF111827),
+      ),
+      typography: ThemeJsonTypography(
+        buttonFontSize: 15,
+        buttonFontWeight: 600,
+        bodyFontSize: 14,
+      ),
+      decoration: ThemeJsonDecoration(
+        radius: 8,
+        buttonRadius: 8,
+        inputRadius: 8,
+        chipRadius: 16,
+        screenPadding: 16,
+      ),
+      components: ThemeJsonComponent(
+        inputFilled: false,
+        appBarCenterTitle: true,
+        chipShowCheckmark: true,
+      ),
+      screen: ThemeJsonScreen(
+        centerTitle: true,
+      ),
+    ),
+  ),
+  ThemePreset(
+    label: 'Rose Dark',
+    config: ThemeJsonConfig(
+      name: 'Rose Dark',
+      mode: Brightness.dark,
+      colors: ThemeJsonColor(
+        primary: Color(0xFFE11D48),
+        secondary: Color(0xFF881337),
+        surface: Color(0xFF1F1720),
+        background: Color(0xFF120A10),
+        error: Color(0xFFFB7185),
+        appBarBackground: Color(0xFF1F1720),
+        appBarForeground: Colors.white,
+      ),
+      typography: ThemeJsonTypography(
+        buttonFontSize: 16,
+        buttonFontWeight: 700,
+        bodyFontSize: 15,
+      ),
+      decoration: ThemeJsonDecoration(
+        radius: 14,
+        buttonRadius: 20,
+        inputRadius: 14,
+        chipRadius: 28,
+        screenPadding: 20,
+      ),
+      components: ThemeJsonComponent(
+        inputFilled: true,
+        appBarCenterTitle: false,
+        chipShowCheckmark: true,
+      ),
+      screen: ThemeJsonScreen(
+        showHeaderImage: true,
+        hasBottomBorderRadius: true,
+        showAppbarDivider: true,
+      ),
+    ),
+  ),
+  ThemePreset(
+    label: 'Forest',
+    config: ThemeJsonConfig(
+      name: 'Forest',
+      colors: ThemeJsonColor(
+        primary: Color(0xFF15803D),
+        secondary: Color(0xFFDCFCE7),
+        surface: Colors.white,
+        background: Color(0xFFF0FDF4),
+        error: Color(0xFFB91C1C),
+        appBarBackground: Color(0xFF14532D),
+        appBarForeground: Colors.white,
+      ),
+      typography: ThemeJsonTypography(
+        buttonFontSize: 14,
+        buttonFontWeight: 500,
+        bodyFontSize: 14,
+      ),
+      decoration: ThemeJsonDecoration(
+        radius: 12,
+        buttonRadius: 10,
+        inputRadius: 12,
+        chipRadius: 12,
+        screenPadding: 18,
+      ),
+      components: ThemeJsonComponent(
+        inputFilled: true,
+        appBarCenterTitle: true,
+        chipShowCheckmark: false,
+      ),
+      screen: ThemeJsonScreen(
+        hasBottomBorderRadius: true,
+        centerTitle: true,
+      ),
+    ),
+  ),
+  ThemePreset(
+    label: 'Minimal Mono',
+    config: ThemeJsonConfig(
+      name: 'Minimal Mono',
+      useMaterial3: false,
+      fontFamily: 'monospace',
+      colors: ThemeJsonColor(
+        primary: Color(0xFF111827),
+        secondary: Color(0xFFE5E7EB),
+        surface: Color(0xFFFFFFFF),
+        background: Color(0xFFFAFAFA),
+        error: Color(0xFFDC2626),
+        appBarBackground: Color(0xFF111827),
+        appBarForeground: Colors.white,
+      ),
+      typography: ThemeJsonTypography(
+        buttonFontSize: 13,
+        buttonFontWeight: 800,
+        bodyFontSize: 13,
+      ),
+      decoration: ThemeJsonDecoration(
+        radius: 2,
+        buttonRadius: 2,
+        inputRadius: 2,
+        chipRadius: 2,
+        screenPadding: 14,
+      ),
+      components: ThemeJsonComponent(
+        appBarCenterTitle: false,
+        chipShowCheckmark: false,
+      ),
+      screen: ThemeJsonScreen(
+        showAppbarDivider: true,
+      ),
+    ),
+  ),
+];

--- a/plugins/fl_theme/example/lib/src/playground/theme_preview_options.dart
+++ b/plugins/fl_theme/example/lib/src/playground/theme_preview_options.dart
@@ -1,0 +1,52 @@
+import 'package:device_frame/device_frame.dart';
+import 'package:flutter/material.dart';
+
+class ThemePreviewDevice {
+  final String label;
+  final DeviceInfo device;
+
+  const ThemePreviewDevice({required this.label, required this.device});
+}
+
+class ThemePreviewOptions {
+  final bool showDeviceFrame;
+  final ThemePreviewDevice selectedDevice;
+  final Orientation orientation;
+
+  ThemePreviewOptions({
+    this.showDeviceFrame = true,
+    ThemePreviewDevice? selectedDevice,
+    this.orientation = Orientation.portrait,
+  }) : selectedDevice = selectedDevice ?? themePreviewDeviceIPhone13;
+
+  ThemePreviewOptions copyWith({
+    bool? showDeviceFrame,
+    ThemePreviewDevice? selectedDevice,
+    Orientation? orientation,
+  }) {
+    return ThemePreviewOptions(
+      showDeviceFrame: showDeviceFrame ?? this.showDeviceFrame,
+      selectedDevice: selectedDevice ?? this.selectedDevice,
+      orientation: orientation ?? this.orientation,
+    );
+  }
+}
+
+final themePreviewDeviceIPhone13 = ThemePreviewDevice(
+  label: 'iPhone 13',
+  device: Devices.ios.iPhone13,
+);
+final themePreviewDevicePixel9 = ThemePreviewDevice(
+  label: 'Pixel 9',
+  device: Devices.android.googlePixel9,
+);
+final themePreviewDeviceMacBookPro = ThemePreviewDevice(
+  label: 'MacBook Pro',
+  device: Devices.macOS.macBookPro,
+);
+
+final themePreviewDevices = [
+  themePreviewDeviceIPhone13,
+  themePreviewDevicePixel9,
+  themePreviewDeviceMacBookPro,
+];

--- a/plugins/fl_theme/example/lib/src/playground/theme_preview_panel.dart
+++ b/plugins/fl_theme/example/lib/src/playground/theme_preview_panel.dart
@@ -1,0 +1,458 @@
+import 'package:device_frame/device_frame.dart';
+import 'package:fl_theme/fl_theme.dart';
+import 'package:flutter/material.dart';
+
+import 'theme_preview_options.dart';
+
+class ThemePreviewPanel extends StatelessWidget {
+  final ThemePreviewOptions options;
+
+  const ThemePreviewPanel({super.key, required this.options});
+
+  @override
+  Widget build(BuildContext context) {
+    const preview = _PreviewScaffold();
+    if (!options.showDeviceFrame) {
+      return preview;
+    }
+
+    return DeviceFrameTheme(
+      style: DeviceFrameStyle.dark(),
+      child: ColoredBox(
+        color: context.themeColor.background,
+        child: Center(
+          child: Padding(
+            padding: EdgeInsets.all(context.decorationTheme.spaceLg),
+            child: DeviceFrame(
+              device: options.selectedDevice.device,
+              orientation: options.orientation,
+              screen: Theme(data: Theme.of(context), child: preview),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PreviewScaffold extends StatefulWidget {
+  const _PreviewScaffold();
+
+  @override
+  State<_PreviewScaffold> createState() => _PreviewScaffoldState();
+}
+
+class _PreviewScaffoldState extends State<_PreviewScaffold>
+    with SingleTickerProviderStateMixin {
+  bool checked = true;
+  int selectedIndex = 0;
+  late final TabController tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    tabController = TabController(length: 3, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final decoration = context.decorationTheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Live preview'),
+        bottom: TabBar(
+          controller: tabController,
+          tabs: const [
+            Tab(text: 'Tokens'),
+            Tab(text: 'Inputs'),
+            Tab(text: 'Chrome'),
+          ],
+        ),
+      ),
+      body: ListView(
+        padding: EdgeInsets.all(decoration.screenPadding),
+        children: [
+          const _TypographySection(),
+          const _Gap.large(),
+          const _ButtonSection(),
+          const _Gap.large(),
+          _InputSection(),
+          const _Gap.large(),
+          _SelectionSection(
+            checked: checked,
+            selectedIndex: selectedIndex,
+            onCheckedChanged: (value) {
+              setState(() => checked = value ?? false);
+            },
+            onSelectedIndexChanged: (value) {
+              setState(() => selectedIndex = value);
+            },
+          ),
+          const _Gap.large(),
+          _NavigationSection(
+            selectedIndex: selectedIndex,
+            onDestinationSelected: (value) {
+              setState(() => selectedIndex = value.clamp(0, 1));
+            },
+          ),
+          const _Gap.large(),
+          const _MenuSection(),
+          const _Gap.large(),
+          const _SurfaceSection(),
+          const _Gap.large(),
+          const _ScreenChromeSection(),
+        ],
+      ),
+    );
+  }
+}
+
+class _TypographySection extends StatelessWidget {
+  const _TypographySection();
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = context.textTheme;
+    final decoration = context.decorationTheme;
+
+    return _PreviewSection(
+      title: 'Typography roles',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Display role', style: textTheme.displaySmall),
+          Text('Headline role', style: textTheme.headlineSmall),
+          Text('Title role', style: textTheme.titleLarge),
+          Text('Body role from JSON typography', style: textTheme.bodyMedium),
+          Text('Input title role', style: textTheme.inputTitle),
+          Text('Input error role', style: textTheme.inputError),
+          SizedBox(height: decoration.spaceSm),
+          FilledButton(onPressed: () {}, child: const Text('Button text role')),
+        ],
+      ),
+    );
+  }
+}
+
+class _ButtonSection extends StatelessWidget {
+  const _ButtonSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final decoration = context.decorationTheme;
+    return _PreviewSection(
+      title: 'Buttons',
+      child: Wrap(
+        spacing: decoration.spaceSm,
+        runSpacing: decoration.spaceSm,
+        children: [
+          ElevatedButton(onPressed: () {}, child: const Text('Elevated')),
+          const ElevatedButton(onPressed: null, child: Text('Disabled')),
+          OutlinedButton(onPressed: () {}, child: const Text('Outlined')),
+          const OutlinedButton(onPressed: null, child: Text('Disabled')),
+          TextButton(onPressed: () {}, child: const Text('Text')),
+          const TextButton(onPressed: null, child: Text('Disabled')),
+        ],
+      ),
+    );
+  }
+}
+
+class _InputSection extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final decoration = context.decorationTheme;
+    return _PreviewSection(
+      title: 'Inputs',
+      child: Column(
+        children: [
+          TextField(
+            decoration: InputDecoration(
+              labelText: 'Normal input',
+              hintText: 'Configured by JSON tokens',
+              helperText:
+                  'Input radius ${decoration.inputRadius.toStringAsFixed(0)}',
+            ),
+          ),
+          SizedBox(height: decoration.spaceMd),
+          const TextField(
+            decoration: InputDecoration(
+              labelText: 'Error input',
+              errorText: 'Error color and text role',
+              hintText: 'Validation preview',
+            ),
+          ),
+          SizedBox(height: decoration.spaceMd),
+          const TextField(
+            enabled: false,
+            decoration: InputDecoration(
+              labelText: 'Disabled input',
+              hintText: 'Disabled border/color preview',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SelectionSection extends StatelessWidget {
+  final bool checked;
+  final int selectedIndex;
+  final ValueChanged<bool?> onCheckedChanged;
+  final ValueChanged<int> onSelectedIndexChanged;
+
+  const _SelectionSection({
+    required this.checked,
+    required this.selectedIndex,
+    required this.onCheckedChanged,
+    required this.onSelectedIndexChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final decoration = context.decorationTheme;
+    return _PreviewSection(
+      title: 'Selection components',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          CheckboxListTile(
+            value: checked,
+            onChanged: onCheckedChanged,
+            title: const Text('Checkbox theme'),
+            contentPadding: EdgeInsets.zero,
+          ),
+          Wrap(
+            spacing: decoration.spaceSm,
+            runSpacing: decoration.spaceSm,
+            children: [
+              ChoiceChip(
+                label: const Text('Selected chip'),
+                selected: selectedIndex == 0,
+                onSelected: (_) => onSelectedIndexChanged(0),
+              ),
+              ChoiceChip(
+                label: const Text('Choice chip'),
+                selected: selectedIndex == 1,
+                onSelected: (_) => onSelectedIndexChanged(1),
+              ),
+              const Chip(label: Text('Static chip')),
+              const InputChip(
+                label: Text('Disabled chip'),
+                isEnabled: false,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NavigationSection extends StatelessWidget {
+  final int selectedIndex;
+  final ValueChanged<int> onDestinationSelected;
+
+  const _NavigationSection({
+    required this.selectedIndex,
+    required this.onDestinationSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return _PreviewSection(
+      title: 'Navigation',
+      child: NavigationBar(
+        selectedIndex: selectedIndex,
+        onDestinationSelected: onDestinationSelected,
+        destinations: const [
+          NavigationDestination(icon: Icon(Icons.palette), label: 'Theme'),
+          NavigationDestination(icon: Icon(Icons.widgets), label: 'UI'),
+        ],
+      ),
+    );
+  }
+}
+
+class _MenuSection extends StatelessWidget {
+  const _MenuSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final decoration = context.decorationTheme;
+    return _PreviewSection(
+      title: 'Menus',
+      child: Wrap(
+        spacing: decoration.spaceSm,
+        runSpacing: decoration.spaceSm,
+        children: [
+          PopupMenuButton<String>(
+            itemBuilder: (context) => const [
+              PopupMenuItem(value: 'copy', child: Text('Copy theme')),
+              PopupMenuItem(value: 'export', child: Text('Export JSON')),
+            ],
+            child: const InputChip(label: Text('Popup menu')),
+          ),
+          MenuAnchor(
+            menuChildren: const [
+              MenuItemButton(child: Text('Preset action')),
+              MenuItemButton(child: Text('Preview action')),
+            ],
+            builder: (context, controller, child) {
+              return FilledButton.tonal(
+                onPressed: () {
+                  if (controller.isOpen) {
+                    controller.close();
+                  } else {
+                    controller.open();
+                  }
+                },
+                child: const Text('Menu anchor'),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SurfaceSection extends StatelessWidget {
+  const _SurfaceSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final decoration = context.decorationTheme;
+    final colors = context.themeColor;
+    return _PreviewSection(
+      title: 'Surfaces and tokens',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Card(
+            child: Padding(
+              padding: EdgeInsets.all(decoration.spaceLg),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Card surface', style: context.textTheme.titleMedium),
+                  SizedBox(height: decoration.spaceSm),
+                  Text('Primary ${themeColorToHex(colors.primary)}'),
+                  Text('Surface ${themeColorToHex(colors.surface)}'),
+                  Text('Background ${themeColorToHex(colors.background)}'),
+                  Text('Error ${themeColorToHex(colors.error)}'),
+                ],
+              ),
+            ),
+          ),
+          SizedBox(height: decoration.spaceMd),
+          Container(
+            padding: EdgeInsets.all(decoration.spaceLg),
+            decoration: BoxDecoration(
+              color: colors.surface,
+              borderRadius: decoration.radiusLgBorder,
+              border: Border.all(color: colors.borderColor),
+              boxShadow: colors.boxShadowLightest,
+            ),
+            child: Text(
+              'Dialog-like surface with decoration tokens',
+              style: context.textTheme.bodyMedium,
+            ),
+          ),
+          SizedBox(height: decoration.spaceMd),
+          const Divider(),
+          const ListTile(
+            leading: Icon(Icons.layers),
+            title: Text('Divider and list tile'),
+            subtitle: Text('Material surface and text roles'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ScreenChromeSection extends StatelessWidget {
+  const _ScreenChromeSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final screen = context.screenTheme;
+    final form = screen.screenFormTheme;
+    final main = screen.mainPageFormTheme;
+    return _PreviewSection(
+      title: 'Screen chrome extension',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _TokenRow('Form header image', form.showHeaderImage.toString()),
+          _TokenRow(
+              'Form bottom radius', form.hasBottomBorderRadius.toString()),
+          _TokenRow('Form title centered', form.centerTitle.toString()),
+          _TokenRow('Form app bar divider', form.showAppbarDivider.toString()),
+          _TokenRow('Main header image', main.showHeaderImage.toString()),
+          _TokenRow(
+              'Main bottom radius', main.hasBottomBorderRadius.toString()),
+          _TokenRow('Main app bar divider', main.showAppbarDivider.toString()),
+        ],
+      ),
+    );
+  }
+}
+
+class _TokenRow extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _TokenRow(this.label, this.value);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: context.decorationTheme.spaceXxs),
+      child: Row(
+        children: [
+          Expanded(child: Text(label)),
+          Text(value, style: context.textTheme.labelLarge),
+        ],
+      ),
+    );
+  }
+}
+
+class _PreviewSection extends StatelessWidget {
+  final String title;
+  final Widget child;
+
+  const _PreviewSection({required this.title, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    final decoration = context.decorationTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(title, style: context.textTheme.titleLarge),
+        SizedBox(height: decoration.spaceSm),
+        child,
+      ],
+    );
+  }
+}
+
+class _Gap extends StatelessWidget {
+  const _Gap.large();
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(height: context.decorationTheme.spaceLg);
+  }
+}

--- a/plugins/fl_theme/example/lib/src/theme_playground_app.dart
+++ b/plugins/fl_theme/example/lib/src/theme_playground_app.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+import 'playground/theme_playground_screen.dart';
+
+class ThemePlaygroundApp extends StatelessWidget {
+  const ThemePlaygroundApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      debugShowCheckedModeBanner: false,
+      title: 'fl_theme playground',
+      home: ThemePlaygroundScreen(),
+    );
+  }
+}

--- a/plugins/fl_theme/example/pubspec.lock
+++ b/plugins/fl_theme/example/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.9"
+  device_frame:
+    dependency: "direct main"
+    description:
+      name: device_frame
+      sha256: "7b2ebb2a09d6cc0f086b51bd1412d7be83e0170056a7290349169be41164c86a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   encrypt:
     dependency: transitive
     description:
@@ -121,14 +129,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
-  file:
-    dependency: transitive
-    description:
-      name: file
-      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.1"
   fl_theme:
     dependency: "direct main"
     description:
@@ -143,13 +143,24 @@ packages:
       relative: true
     source: path
     version: "1.0.0"
+  flex_color_scheme:
+    dependency: transitive
+    description:
+      name: flex_color_scheme
+      sha256: ab854146f201d2d62cc251fd525ef023b84182c4a0bfe4ae4c18ffc505b412d3
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.4.0"
+  flex_seed_scheme:
+    dependency: transitive
+    description:
+      name: flex_seed_scheme
+      sha256: a3183753bbcfc3af106224bff3ab3e1844b73f58062136b7499919f49f3667e7
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
   flutter:
     dependency: "direct main"
-    description: flutter
-    source: sdk
-    version: "0.0.0"
-  flutter_driver:
-    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -174,16 +185,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  fuchsia_remote_debug_protocol:
+  freezed_annotation:
     dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
-  integration_test:
-    dependency: "direct dev"
-    description: flutter
-    source: sdk
-    version: "0.0.0"
+    description:
+      name: freezed_annotation
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   intl:
     dependency: transitive
     description:
@@ -200,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.2"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.11.0"
   jwt_decode:
     dependency: transitive
     description:
@@ -304,14 +321,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.0.11"
-  platform:
-    dependency: transitive
-    description:
-      name: platform
-      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.6"
   pointycastle:
     dependency: transitive
     description:
@@ -320,14 +329,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.9.1"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -365,14 +366,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
-  sync_http:
-    dependency: transitive
-    description:
-      name: sync_http
-      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -421,14 +414,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.0"
-  webdriver:
-    dependency: transitive
-    description:
-      name: webdriver
-      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
-  flutter: ">=3.32.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/plugins/fl_theme/example/pubspec.yaml
+++ b/plugins/fl_theme/example/pubspec.yaml
@@ -29,10 +29,9 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
+  device_frame: ^1.4.0
 
 dev_dependencies:
-  integration_test:
-    sdk: flutter
   flutter_test:
     sdk: flutter
 

--- a/plugins/fl_theme/example/test/widget_test.dart
+++ b/plugins/fl_theme/example/test/widget_test.dart
@@ -1,27 +1,90 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
+import 'package:fl_theme_example/src/theme_playground_app.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:fl_theme_example/main.dart';
-
 void main() {
-  testWidgets('Verify Platform version', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('renders theme playground sections', (tester) async {
+    await tester.pumpWidget(const ThemePlaygroundApp());
 
-    // Verify that platform version is retrieved.
-    expect(
-      find.byWidgetPredicate(
-        (Widget widget) =>
-            widget is Text && widget.data!.startsWith('Running on:'),
-      ),
-      findsOneWidget,
+    expect(find.text('fl_theme JSON playground'), findsOneWidget);
+    expect(find.text('Theme controls'), findsOneWidget);
+    expect(find.text('Preset and mode'), findsOneWidget);
+    expect(find.text('Colors'), findsOneWidget);
+  });
+
+  testWidgets('preset switch updates controls and title', (tester) async {
+    await tester.pumpWidget(const ThemePlaygroundApp());
+
+    await tester.tap(find.text('Ocean Blue').first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Rose Dark').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Rose Dark'), findsWidgets);
+    expect(find.text('Dark mode'), findsNothing);
+    expect(find.text('Mode'), findsOneWidget);
+  });
+
+  testWidgets('applies JSON edits', (tester) async {
+    await tester.pumpWidget(const ThemePlaygroundApp());
+
+    await tester.tap(find.text('JSON'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('theme_json_field')),
+      '''
+{
+  "name": "Test Theme",
+  "mode": "light",
+  "colors": {
+    "primary": "#FF0000",
+    "secondary": "#FFF1F2"
+  }
+}
+''',
     );
+    await tester.tap(find.text('Apply JSON'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Test Theme'), findsOneWidget);
+  });
+
+  testWidgets('invalid JSON shows an error and keeps typed text',
+      (tester) async {
+    await tester.pumpWidget(const ThemePlaygroundApp());
+
+    await tester.tap(find.text('JSON'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('theme_json_field')),
+      '{"colors":{"primary":"nope"}}',
+    );
+    await tester.tap(find.text('Apply JSON'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('colors.primary must be #RRGGBB or #AARRGGBB'),
+        findsOneWidget);
+    expect(find.textContaining('nope'), findsOneWidget);
+  });
+
+  testWidgets('device frame toggle is preview-only', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(const ThemePlaygroundApp());
+
+    await tester.dragUntilVisible(
+      find.text('Show device frame'),
+      find.byKey(const ValueKey('theme_controls_list')),
+      const Offset(0, -400),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(SwitchListTile, 'Show device frame'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('frame')), findsOneWidget);
+
+    await tester.tap(find.text('JSON'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('showDeviceFrame'), findsNothing);
+    expect(find.textContaining('deviceIndex'), findsNothing);
   });
 }

--- a/plugins/fl_theme/example/web/index.html
+++ b/plugins/fl_theme/example/web/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base href="$FLUTTER_BASE_HREF">
+  <meta charset="UTF-8">
+  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <meta name="description" content="fl_theme JSON theme playground">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="fl_theme playground">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%232563EB'/%3E%3Ccircle cx='42' cy='24' r='13' fill='%23F59E0B'/%3E%3Cpath d='M14 46h36' stroke='white' stroke-width='8' stroke-linecap='round'/%3E%3C/svg%3E">
+  <title>fl_theme playground</title>
+</head>
+<body>
+  <script src="flutter_bootstrap.js" async></script>
+</body>
+</html>

--- a/plugins/fl_theme/example/web/manifest.json
+++ b/plugins/fl_theme/example/web/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "fl_theme JSON playground",
+  "short_name": "fl_theme",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#FFFFFF",
+  "theme_color": "#3B82F6",
+  "description": "Preview and export JSON theme configurations for fl_theme."
+}

--- a/plugins/fl_theme/lib/fl_theme.dart
+++ b/plugins/fl_theme/lib/fl_theme.dart
@@ -1,7 +1,18 @@
 library fl_theme;
 
+export 'src/app_component_theme.dart';
+export 'src/app_decoration_theme.dart';
+export 'src/app_design_system.dart';
 export 'src/app_text_theme.dart';
+export 'src/app_typography_theme.dart';
 export 'src/extension.dart';
+export 'src/json/theme_json_codec.dart';
+export 'src/json/theme_json_color.dart';
+export 'src/json/theme_json_component.dart';
+export 'src/json/theme_json_config.dart';
+export 'src/json/theme_json_decoration.dart';
+export 'src/json/theme_json_screen.dart';
+export 'src/json/theme_json_typography.dart';
 export 'src/screen_theme.dart';
 export 'src/theme_button.dart';
 export 'src/theme_color.dart';

--- a/plugins/fl_theme/lib/src/app_component_theme.dart
+++ b/plugins/fl_theme/lib/src/app_component_theme.dart
@@ -1,0 +1,526 @@
+import 'package:flex_color_scheme/flex_color_scheme.dart';
+import 'package:flutter/material.dart';
+
+import 'app_decoration_theme.dart';
+import 'app_text_theme.dart';
+import 'json/theme_json_component.dart';
+import 'theme_color.dart';
+
+/// Configures Material component behavior that belongs to the design system.
+///
+/// `AppComponentTheme` captures the small set of component decisions this
+/// plugin owns directly. Broader Material defaults still come from
+/// FlexColorScheme, and
+/// these values are passed into Flex sub-theme data or post-processed component
+/// themes where the app needs semantic colors and decoration tokens.
+class AppComponentTheme {
+  /// Whether input decorations should render with a filled background.
+  final bool inputFilled;
+
+  /// Whether app bar titles should be centered by default.
+  final bool appBarCenterTitle;
+
+  /// Whether selectable chips should show Material checkmarks.
+  final bool chipShowCheckmark;
+
+  /// Creates component defaults for generated app themes.
+  const AppComponentTheme({
+    this.inputFilled = false,
+    this.appBarCenterTitle = true,
+    this.chipShowCheckmark = true,
+  });
+
+  /// Creates component settings from a JSON theme component section.
+  factory AppComponentTheme.fromJsonConfig(ThemeJsonComponent config) {
+    return AppComponentTheme(
+      inputFilled: config.inputFilled,
+      appBarCenterTitle: config.appBarCenterTitle,
+      chipShowCheckmark: config.chipShowCheckmark,
+    );
+  }
+
+  /// Converts these component settings to their JSON DTO.
+  ThemeJsonComponent toJsonConfig() {
+    return ThemeJsonComponent(
+      inputFilled: inputFilled,
+      appBarCenterTitle: appBarCenterTitle,
+      chipShowCheckmark: chipShowCheckmark,
+    );
+  }
+
+  /// Creates FlexColorScheme sub-theme settings from app design tokens.
+  ///
+  /// This is used before `FlexColorScheme.toTheme` so generated Material
+  /// widgets
+  /// pick up the same radius, padding, border, and typography decisions exposed
+  /// through [AppDecorationTheme] and [AppTextTheme].
+  FlexSubThemesData flexSubThemesData({
+    required AppDecorationTheme decoration,
+    required AppTextTheme textTheme,
+  }) {
+    return FlexSubThemesData(
+      defaultRadius: decoration.radiusMd,
+      buttonMinSize: decoration.buttonMinSize,
+      buttonPadding: decoration.buttonPadding,
+      thinBorderWidth: decoration.borderThin,
+      thickBorderWidth: decoration.borderRegular,
+      textButtonRadius: decoration.buttonRadius,
+      elevatedButtonRadius: decoration.buttonRadius,
+      elevatedButtonElevation: decoration.elevationNone,
+      outlinedButtonRadius: decoration.buttonRadius,
+      inputDecoratorRadius: decoration.inputRadius,
+      inputDecoratorContentPadding: decoration.inputPadding,
+      inputDecoratorIsFilled: inputFilled,
+      checkboxSchemeColor: SchemeColor.primary,
+      chipRadius: decoration.chipRadius,
+      chipPadding: decoration.chipPadding,
+      chipLabelStyle: textTheme.bodyMedium,
+      chipSecondaryLabelStyle: textTheme.bodySmall,
+      appBarCenterTitle: appBarCenterTitle,
+      useMaterial3Typography: true,
+    );
+  }
+
+  /// Builds the app input decoration theme from semantic colors and tokens.
+  InputDecorationTheme inputDecorationTheme({
+    required ThemeColor colors,
+    required AppTextTheme textTheme,
+    required AppDecorationTheme decoration,
+  }) {
+    OutlineInputBorder border(Color color) {
+      return OutlineInputBorder(
+        borderSide: BorderSide(color: color, width: decoration.borderThin),
+        borderRadius: decoration.inputRadiusBorder,
+      );
+    }
+
+    return InputDecorationTheme(
+      border: border(colors.borderColor),
+      enabledBorder: border(colors.borderColor),
+      focusedBorder: border(colors.primary),
+      disabledBorder: border(colors.disableColor),
+      errorBorder: border(textTheme.inputError?.color ?? colors.error),
+      floatingLabelBehavior: FloatingLabelBehavior.auto,
+      labelStyle: textTheme.inputTitle,
+      floatingLabelStyle: textTheme.inputTitle,
+      contentPadding: decoration.inputPadding,
+      filled: inputFilled,
+      fillColor: inputFilled ? colors.surface : null,
+    );
+  }
+
+  /// Builds the checkbox theme from semantic colors and tokens.
+  CheckboxThemeData checkboxTheme({
+    required ThemeColor colors,
+    required AppDecorationTheme decoration,
+  }) {
+    return CheckboxThemeData(
+      checkColor: WidgetStateProperty.resolveWith<Color?>((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return colors.checkboxCheckColor.withValues(alpha: 0.5);
+        }
+        return colors.checkboxCheckColor;
+      }),
+      fillColor: WidgetStateProperty.resolveWith<Color?>((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return colors.checkboxDisabledColor;
+        }
+        if (states.contains(WidgetState.selected)) {
+          return colors.checkboxActiveColor;
+        }
+        return Colors.transparent;
+      }),
+      overlayColor: WidgetStateProperty.resolveWith<Color?>((states) {
+        if (states.contains(WidgetState.pressed)) {
+          return colors.checkboxActiveColor.withValues(alpha: 0.1);
+        }
+        if (states.contains(WidgetState.hovered)) {
+          return colors.checkboxActiveColor.withValues(alpha: 0.08);
+        }
+        if (states.contains(WidgetState.focused)) {
+          return colors.checkboxActiveColor.withValues(alpha: 0.12);
+        }
+        return null;
+      }),
+      side: WidgetStateBorderSide.resolveWith((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return BorderSide(
+            color: colors.checkboxDisabledColor,
+            width: decoration.borderThin,
+          );
+        }
+        if (states.contains(WidgetState.selected)) {
+          return BorderSide(
+            color: colors.checkboxActiveColor,
+            width: decoration.borderThin,
+          );
+        }
+        return BorderSide(
+          color: colors.checkboxBorderColor,
+          width: decoration.borderThin,
+        );
+      }),
+      shape: RoundedRectangleBorder(borderRadius: decoration.radiusXsBorder),
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      visualDensity: VisualDensity.compact,
+    );
+  }
+
+  /// Builds the chip theme from semantic colors and tokens.
+  ChipThemeData chipTheme({
+    required ThemeColor colors,
+    required AppTextTheme textTheme,
+    required AppDecorationTheme decoration,
+  }) {
+    return ChipThemeData(
+      backgroundColor: colors.chipBackgroundColor,
+      disabledColor: colors.chipDisabledColor,
+      selectedColor: colors.chipSelectedColor,
+      secondarySelectedColor: colors.chipSelectedColor.withValues(alpha: 0.12),
+      padding: decoration.chipPadding,
+      labelStyle: textTheme.bodyMedium?.copyWith(color: colors.chipLabelColor),
+      secondaryLabelStyle: textTheme.bodySmall?.copyWith(
+        color: colors.chipLabelColor,
+      ),
+      brightness: colors.brightness,
+      elevation: decoration.elevationNone,
+      pressElevation: decoration.elevationSm,
+      shape: RoundedRectangleBorder(
+        borderRadius: decoration.chipRadiusBorder,
+        side: BorderSide(
+          color: colors.chipBorderColor,
+          width: decoration.borderThin,
+        ),
+      ),
+      selectedShadowColor: Colors.transparent,
+      showCheckmark: chipShowCheckmark,
+      checkmarkColor: colors.checkboxCheckColor,
+      deleteIconColor: colors.deleteIconColor,
+      iconTheme: IconThemeData(color: colors.chipLabelColor, size: 18),
+    );
+  }
+
+  /// Builds the card theme from semantic colors and decoration tokens.
+  CardThemeData cardTheme({
+    required ThemeColor colors,
+    required AppDecorationTheme decoration,
+  }) {
+    return CardThemeData(
+      clipBehavior: Clip.antiAlias,
+      color: colors.cardBackground,
+      shadowColor: colors.shadowColor.withValues(alpha: 0.16),
+      surfaceTintColor: Colors.transparent,
+      elevation: decoration.elevationSm,
+      margin: EdgeInsets.all(decoration.spaceSm),
+      shape: RoundedRectangleBorder(
+        borderRadius: decoration.radiusLgBorder,
+        side: BorderSide(
+          color: colors.borderColor.withValues(alpha: 0.12),
+          width: decoration.borderThin,
+        ),
+      ),
+    );
+  }
+
+  /// Builds the scrollbar theme from semantic colors and spacing tokens.
+  ScrollbarThemeData scrollbarTheme({
+    required ThemeColor colors,
+    required AppDecorationTheme decoration,
+  }) {
+    return ScrollbarThemeData(
+      radius: Radius.circular(decoration.radiusPill),
+      thickness: WidgetStateProperty.resolveWith((states) {
+        if (states.contains(WidgetState.hovered) ||
+            states.contains(WidgetState.dragged)) {
+          return decoration.spaceSm;
+        }
+        return decoration.spaceXs;
+      }),
+      thumbColor: WidgetStateProperty.resolveWith((states) {
+        final alpha = states.contains(WidgetState.dragged) ? 0.72 : 0.48;
+        return colors.primary.withValues(alpha: alpha);
+      }),
+      trackColor: WidgetStateProperty.all(
+        colors.surface.withValues(alpha: 0.32),
+      ),
+      trackBorderColor: WidgetStateProperty.all(Colors.transparent),
+      minThumbLength: decoration.spaceXxl,
+      interactive: true,
+    );
+  }
+
+  /// Builds the dialog theme from semantic colors, text roles, and tokens.
+  DialogThemeData dialogTheme({
+    required ThemeColor colors,
+    required AppTextTheme textTheme,
+    required AppDecorationTheme decoration,
+  }) {
+    return DialogThemeData(
+      backgroundColor: colors.cardBackground,
+      elevation: decoration.elevationMd,
+      shadowColor: colors.shadowColor.withValues(alpha: 0.2),
+      surfaceTintColor: Colors.transparent,
+      shape: RoundedRectangleBorder(borderRadius: decoration.radiusXlBorder),
+      titleTextStyle: textTheme.titleLarge,
+      contentTextStyle: textTheme.bodyMedium,
+      iconColor: colors.primary,
+      actionsPadding: EdgeInsets.all(decoration.spaceLg),
+      insetPadding: EdgeInsets.all(decoration.screenPadding),
+      clipBehavior: Clip.antiAlias,
+    );
+  }
+
+  /// Builds the bottom sheet theme from semantic colors and radius tokens.
+  BottomSheetThemeData bottomSheetTheme({
+    required ThemeColor colors,
+    required AppDecorationTheme decoration,
+  }) {
+    final shape = RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(decoration.radiusXl),
+      ),
+    );
+    return BottomSheetThemeData(
+      backgroundColor: colors.cardBackground,
+      modalBackgroundColor: colors.cardBackground,
+      surfaceTintColor: Colors.transparent,
+      elevation: decoration.elevationMd,
+      modalElevation: decoration.elevationMd,
+      shadowColor: colors.shadowColor.withValues(alpha: 0.2),
+      modalBarrierColor: Colors.black.withValues(alpha: 0.48),
+      shape: shape,
+      showDragHandle: true,
+      dragHandleColor: colors.borderColor,
+      clipBehavior: Clip.antiAlias,
+    );
+  }
+
+  /// Builds the snackbar theme from semantic colors, text roles, and tokens.
+  SnackBarThemeData snackBarTheme({
+    required ThemeColor colors,
+    required AppTextTheme textTheme,
+    required AppDecorationTheme decoration,
+  }) {
+    return SnackBarThemeData(
+      backgroundColor: colors.onSurface,
+      actionTextColor: colors.primary,
+      disabledActionTextColor: colors.disableColor,
+      closeIconColor: colors.surface,
+      contentTextStyle: textTheme.bodyMedium?.copyWith(color: colors.surface),
+      elevation: decoration.elevationMd,
+      shape: RoundedRectangleBorder(borderRadius: decoration.radiusMdBorder),
+      behavior: SnackBarBehavior.floating,
+      insetPadding: EdgeInsets.all(decoration.spaceLg),
+    );
+  }
+
+  /// Builds list tile defaults from semantic text and color roles.
+  ListTileThemeData listTileTheme({
+    required ThemeColor colors,
+    required AppTextTheme textTheme,
+    required AppDecorationTheme decoration,
+  }) {
+    return ListTileThemeData(
+      shape: RoundedRectangleBorder(borderRadius: decoration.radiusMdBorder),
+      selectedColor: colors.primary,
+      iconColor: colors.labelText,
+      textColor: colors.bodyText,
+      titleTextStyle: textTheme.titleMedium,
+      subtitleTextStyle: textTheme.bodySmall?.copyWith(color: colors.labelText),
+      leadingAndTrailingTextStyle: textTheme.labelMedium,
+      contentPadding: EdgeInsets.symmetric(horizontal: decoration.spaceLg),
+      tileColor: Colors.transparent,
+      selectedTileColor: colors.primary.withValues(alpha: 0.08),
+      horizontalTitleGap: decoration.spaceMd,
+      minVerticalPadding: decoration.spaceSm,
+      visualDensity: VisualDensity.compact,
+    );
+  }
+
+  /// Builds app-wide icon defaults from semantic color roles.
+  IconThemeData iconTheme({required ThemeColor colors}) {
+    return IconThemeData(color: colors.labelText, size: 24);
+  }
+
+  /// Builds floating action button defaults from semantic colors and tokens.
+  FloatingActionButtonThemeData floatingActionButtonTheme({
+    required ThemeColor colors,
+    required AppTextTheme textTheme,
+    required AppDecorationTheme decoration,
+  }) {
+    return FloatingActionButtonThemeData(
+      foregroundColor: colors.onPrimary,
+      backgroundColor: colors.primary,
+      focusColor: colors.primary.withValues(alpha: 0.12),
+      hoverColor: colors.primary.withValues(alpha: 0.08),
+      splashColor: colors.splashColor.withValues(alpha: 0.16),
+      elevation: decoration.elevationSm,
+      focusElevation: decoration.elevationMd,
+      hoverElevation: decoration.elevationMd,
+      highlightElevation: decoration.elevationMd,
+      disabledElevation: decoration.elevationNone,
+      shape: RoundedRectangleBorder(
+        borderRadius: decoration.buttonRadiusBorder,
+      ),
+      iconSize: 24,
+      extendedPadding: decoration.buttonPadding,
+      extendedTextStyle: textTheme.buttonText,
+    );
+  }
+
+  /// Builds navigation bar defaults from semantic colors and text roles.
+  NavigationBarThemeData navigationBarTheme({
+    required ThemeColor colors,
+    required AppTextTheme textTheme,
+    required AppDecorationTheme decoration,
+  }) {
+    return NavigationBarThemeData(
+      height: decoration.spaceXxl + 48,
+      backgroundColor: colors.cardBackground,
+      elevation: decoration.elevationNone,
+      shadowColor: Colors.transparent,
+      surfaceTintColor: Colors.transparent,
+      indicatorColor: colors.primary.withValues(alpha: 0.12),
+      indicatorShape: RoundedRectangleBorder(
+        borderRadius: decoration.radiusPillBorder,
+      ),
+      labelTextStyle: WidgetStateProperty.resolveWith((states) {
+        final color = states.contains(WidgetState.selected)
+            ? colors.primary
+            : colors.labelText;
+        return textTheme.labelMedium?.copyWith(color: color);
+      }),
+      iconTheme: WidgetStateProperty.resolveWith((states) {
+        final color = states.contains(WidgetState.selected)
+            ? colors.primary
+            : colors.labelText;
+        return IconThemeData(color: color, size: 24);
+      }),
+      overlayColor: WidgetStateProperty.all(
+        colors.primary.withValues(alpha: 0.08),
+      ),
+      labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
+    );
+  }
+
+  /// Builds drawer defaults from semantic colors and radius tokens.
+  DrawerThemeData drawerTheme({
+    required ThemeColor colors,
+    required AppDecorationTheme decoration,
+  }) {
+    final radius = Radius.circular(decoration.radiusXl);
+    return DrawerThemeData(
+      backgroundColor: colors.cardBackground,
+      scrimColor: Colors.black.withValues(alpha: 0.48),
+      elevation: decoration.elevationMd,
+      shadowColor: colors.shadowColor.withValues(alpha: 0.2),
+      surfaceTintColor: Colors.transparent,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.horizontal(right: radius),
+      ),
+      endShape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.horizontal(left: radius),
+      ),
+      clipBehavior: Clip.antiAlias,
+    );
+  }
+
+  /// Builds tooltip defaults from semantic text and decoration tokens.
+  TooltipThemeData tooltipTheme({
+    required ThemeColor colors,
+    required AppTextTheme textTheme,
+    required AppDecorationTheme decoration,
+  }) {
+    return TooltipThemeData(
+      constraints: BoxConstraints(minHeight: decoration.spaceXxl),
+      padding: EdgeInsets.symmetric(
+        horizontal: decoration.spaceMd,
+        vertical: decoration.spaceSm,
+      ),
+      margin: EdgeInsets.all(decoration.spaceSm),
+      verticalOffset: decoration.spaceLg,
+      preferBelow: false,
+      decoration: BoxDecoration(
+        color: colors.onSurface,
+        borderRadius: decoration.radiusSmBorder,
+      ),
+      textStyle: textTheme.bodySmall?.copyWith(color: colors.surface),
+    );
+  }
+
+  /// Builds progress indicator defaults from semantic colors and radius tokens.
+  ProgressIndicatorThemeData progressIndicatorTheme({
+    required ThemeColor colors,
+    required AppDecorationTheme decoration,
+  }) {
+    return ProgressIndicatorThemeData(
+      color: colors.primary,
+      linearTrackColor: colors.primary.withValues(alpha: 0.16),
+      circularTrackColor: colors.primary.withValues(alpha: 0.16),
+      refreshBackgroundColor: colors.surface,
+      linearMinHeight: decoration.spaceXs,
+      borderRadius: decoration.radiusPillBorder,
+      strokeWidth: decoration.borderRegular * 3,
+      strokeCap: StrokeCap.round,
+    );
+  }
+
+  /// Builds switch defaults from semantic colors and component density tokens.
+  SwitchThemeData switchTheme({required ThemeColor colors}) {
+    return SwitchThemeData(
+      thumbColor: WidgetStateProperty.resolveWith((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return colors.disableColor;
+        }
+        if (states.contains(WidgetState.selected)) {
+          return colors.onPrimary;
+        }
+        return colors.surface;
+      }),
+      trackColor: WidgetStateProperty.resolveWith((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return colors.disableColor.withValues(alpha: 0.32);
+        }
+        if (states.contains(WidgetState.selected)) {
+          return colors.primary;
+        }
+        return colors.borderColor;
+      }),
+      trackOutlineColor: WidgetStateProperty.all(Colors.transparent),
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    );
+  }
+
+  /// Builds radio defaults from semantic colors and component density tokens.
+  RadioThemeData radioTheme({required ThemeColor colors}) {
+    return RadioThemeData(
+      fillColor: WidgetStateProperty.resolveWith((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return colors.disableColor;
+        }
+        if (states.contains(WidgetState.selected)) {
+          return colors.primary;
+        }
+        return colors.borderColor;
+      }),
+      overlayColor: WidgetStateProperty.all(
+        colors.primary.withValues(alpha: 0.08),
+      ),
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      visualDensity: VisualDensity.compact,
+    );
+  }
+
+  /// Creates a copy with selected component settings replaced.
+  AppComponentTheme copyWith({
+    bool? inputFilled,
+    bool? appBarCenterTitle,
+    bool? chipShowCheckmark,
+  }) {
+    return AppComponentTheme(
+      inputFilled: inputFilled ?? this.inputFilled,
+      appBarCenterTitle: appBarCenterTitle ?? this.appBarCenterTitle,
+      chipShowCheckmark: chipShowCheckmark ?? this.chipShowCheckmark,
+    );
+  }
+}

--- a/plugins/fl_theme/lib/src/app_decoration_theme.dart
+++ b/plugins/fl_theme/lib/src/app_decoration_theme.dart
@@ -1,0 +1,322 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import 'json/theme_json_decoration.dart';
+
+/// Theme extension for shared layout and shape design tokens.
+///
+/// `AppDecorationTheme` is attached to generated [ThemeData] by [AppTheme] and
+/// is available through `context.decorationTheme`. Use it for spacing, radius,
+/// padding, borders, and elevation values that should stay consistent across
+/// app
+/// widgets and plugin widgets.
+///
+/// The base [radiusMd] and [screenPadding] values define the general scale.
+/// [buttonRadius], [inputRadius], and [chipRadius] preserve the component-level
+/// values from [ThemeJsonDecoration] so the JSON playground can tune those
+/// Material component shapes independently.
+class AppDecorationTheme extends ThemeExtension<AppDecorationTheme> {
+  /// The smallest corner radius token.
+  final double radiusXs;
+
+  /// The small corner radius token.
+  final double radiusSm;
+
+  /// The default corner radius token.
+  final double radiusMd;
+
+  /// The large corner radius token.
+  final double radiusLg;
+
+  /// The extra-large corner radius token.
+  final double radiusXl;
+
+  /// The pill-shaped corner radius token.
+  final double radiusPill;
+
+  /// The extra-extra-small spacing token.
+  final double spaceXxs;
+
+  /// The extra-small spacing token.
+  final double spaceXs;
+
+  /// The small spacing token.
+  final double spaceSm;
+
+  /// The medium spacing token.
+  final double spaceMd;
+
+  /// The large spacing token.
+  final double spaceLg;
+
+  /// The extra-large spacing token.
+  final double spaceXl;
+
+  /// The extra-extra-large spacing token.
+  final double spaceXxl;
+
+  /// The default horizontal and vertical screen padding.
+  final double screenPadding;
+
+  /// The corner radius used by generated button themes.
+  final double buttonRadius;
+
+  /// The corner radius used by generated input decoration themes.
+  final double inputRadius;
+
+  /// The corner radius used by generated chip themes.
+  final double chipRadius;
+
+  /// The default minimum size for buttons.
+  final Size buttonMinSize;
+
+  /// The default internal padding for buttons.
+  final EdgeInsets buttonPadding;
+
+  /// The default internal padding for input fields.
+  final EdgeInsets inputPadding;
+
+  /// The default internal padding for chips.
+  final EdgeInsets chipPadding;
+
+  /// The thin border width token.
+  final double borderThin;
+
+  /// The regular border width token.
+  final double borderRegular;
+
+  /// The zero elevation token.
+  final double elevationNone;
+
+  /// The small elevation token.
+  final double elevationSm;
+
+  /// The medium elevation token.
+  final double elevationMd;
+
+  /// Creates a decoration token set for app and plugin widgets.
+  ///
+  /// Defaults are intentionally small and Material-friendly: an 8px base
+  /// radius, a 16px screen padding, compact input padding, and no default
+  /// button elevation. Apps can override individual tokens directly or create
+  /// them from
+  /// a JSON decoration section with [AppDecorationTheme.fromJsonConfig].
+  const AppDecorationTheme({
+    this.radiusXs = 4,
+    this.radiusSm = 6,
+    this.radiusMd = 8,
+    this.radiusLg = 12,
+    this.radiusXl = 16,
+    this.radiusPill = 999,
+    this.spaceXxs = 2,
+    this.spaceXs = 4,
+    this.spaceSm = 8,
+    this.spaceMd = 12,
+    this.spaceLg = 16,
+    this.spaceXl = 24,
+    this.spaceXxl = 32,
+    this.screenPadding = 16,
+    this.buttonRadius = 8,
+    this.inputRadius = 8,
+    this.chipRadius = 16,
+    this.buttonMinSize = const Size(88, 40),
+    this.buttonPadding = const EdgeInsets.symmetric(horizontal: 16),
+    this.inputPadding = const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+    this.chipPadding = const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    this.borderThin = 1,
+    this.borderRegular = 1,
+    this.elevationNone = 0,
+    this.elevationSm = 1,
+    this.elevationMd = 8,
+  });
+
+  /// Creates decoration tokens from a JSON theme decoration section.
+  ///
+  /// The JSON [ThemeJsonDecoration.radius] value expands into the general
+  /// radius scale, while [ThemeJsonDecoration.buttonRadius],
+  /// [ThemeJsonDecoration.inputRadius], and
+  /// [ThemeJsonDecoration.chipRadius] are preserved as component-specific
+  /// tokens. [ThemeJsonDecoration.screenPadding] expands into the spacing scale
+  /// and default component padding.
+  factory AppDecorationTheme.fromJsonConfig(ThemeJsonDecoration config) {
+    return AppDecorationTheme(
+      radiusXs: config.radius / 2,
+      radiusSm: config.radius * 0.75,
+      radiusMd: config.radius,
+      radiusLg: config.radius * 1.5,
+      radiusXl: config.radius * 2,
+      radiusPill: 999,
+      spaceXxs: config.screenPadding / 8,
+      spaceXs: config.screenPadding / 4,
+      spaceSm: config.screenPadding / 2,
+      spaceMd: config.screenPadding * 0.75,
+      spaceLg: config.screenPadding,
+      spaceXl: config.screenPadding * 1.5,
+      spaceXxl: config.screenPadding * 2,
+      screenPadding: config.screenPadding,
+      buttonRadius: config.buttonRadius,
+      inputRadius: config.inputRadius,
+      chipRadius: config.chipRadius,
+      buttonPadding: EdgeInsets.symmetric(horizontal: config.screenPadding),
+      inputPadding: EdgeInsets.symmetric(
+        horizontal: config.screenPadding * 0.75,
+        vertical: config.screenPadding * 0.375,
+      ),
+      chipPadding: EdgeInsets.symmetric(
+        horizontal: config.screenPadding * 0.75,
+        vertical: config.screenPadding * 0.5,
+      ),
+    );
+  }
+
+  /// The smallest radius token as a [BorderRadius].
+  BorderRadius get radiusXsBorder => BorderRadius.circular(radiusXs);
+
+  /// The small radius token as a [BorderRadius].
+  BorderRadius get radiusSmBorder => BorderRadius.circular(radiusSm);
+
+  /// The default radius token as a [BorderRadius].
+  BorderRadius get radiusMdBorder => BorderRadius.circular(radiusMd);
+
+  /// The large radius token as a [BorderRadius].
+  BorderRadius get radiusLgBorder => BorderRadius.circular(radiusLg);
+
+  /// The extra-large radius token as a [BorderRadius].
+  BorderRadius get radiusXlBorder => BorderRadius.circular(radiusXl);
+
+  /// The pill radius token as a [BorderRadius].
+  BorderRadius get radiusPillBorder => BorderRadius.circular(radiusPill);
+
+  /// The button radius token as a [BorderRadius].
+  BorderRadius get buttonRadiusBorder => BorderRadius.circular(buttonRadius);
+
+  /// The input radius token as a [BorderRadius].
+  BorderRadius get inputRadiusBorder => BorderRadius.circular(inputRadius);
+
+  /// The chip radius token as a [BorderRadius].
+  BorderRadius get chipRadiusBorder => BorderRadius.circular(chipRadius);
+
+  /// Converts these decoration tokens to their JSON DTO.
+  ThemeJsonDecoration toJsonConfig() {
+    return ThemeJsonDecoration(
+      radius: radiusMd,
+      buttonRadius: buttonRadius,
+      inputRadius: inputRadius,
+      chipRadius: chipRadius,
+      screenPadding: screenPadding,
+    );
+  }
+
+  /// Creates a copy with selected decoration tokens replaced.
+  @override
+  AppDecorationTheme copyWith({
+    double? radiusXs,
+    double? radiusSm,
+    double? radiusMd,
+    double? radiusLg,
+    double? radiusXl,
+    double? radiusPill,
+    double? spaceXxs,
+    double? spaceXs,
+    double? spaceSm,
+    double? spaceMd,
+    double? spaceLg,
+    double? spaceXl,
+    double? spaceXxl,
+    double? screenPadding,
+    double? buttonRadius,
+    double? inputRadius,
+    double? chipRadius,
+    Size? buttonMinSize,
+    EdgeInsets? buttonPadding,
+    EdgeInsets? inputPadding,
+    EdgeInsets? chipPadding,
+    double? borderThin,
+    double? borderRegular,
+    double? elevationNone,
+    double? elevationSm,
+    double? elevationMd,
+  }) {
+    return AppDecorationTheme(
+      radiusXs: radiusXs ?? this.radiusXs,
+      radiusSm: radiusSm ?? this.radiusSm,
+      radiusMd: radiusMd ?? this.radiusMd,
+      radiusLg: radiusLg ?? this.radiusLg,
+      radiusXl: radiusXl ?? this.radiusXl,
+      radiusPill: radiusPill ?? this.radiusPill,
+      spaceXxs: spaceXxs ?? this.spaceXxs,
+      spaceXs: spaceXs ?? this.spaceXs,
+      spaceSm: spaceSm ?? this.spaceSm,
+      spaceMd: spaceMd ?? this.spaceMd,
+      spaceLg: spaceLg ?? this.spaceLg,
+      spaceXl: spaceXl ?? this.spaceXl,
+      spaceXxl: spaceXxl ?? this.spaceXxl,
+      screenPadding: screenPadding ?? this.screenPadding,
+      buttonRadius: buttonRadius ?? this.buttonRadius,
+      inputRadius: inputRadius ?? this.inputRadius,
+      chipRadius: chipRadius ?? this.chipRadius,
+      buttonMinSize: buttonMinSize ?? this.buttonMinSize,
+      buttonPadding: buttonPadding ?? this.buttonPadding,
+      inputPadding: inputPadding ?? this.inputPadding,
+      chipPadding: chipPadding ?? this.chipPadding,
+      borderThin: borderThin ?? this.borderThin,
+      borderRegular: borderRegular ?? this.borderRegular,
+      elevationNone: elevationNone ?? this.elevationNone,
+      elevationSm: elevationSm ?? this.elevationSm,
+      elevationMd: elevationMd ?? this.elevationMd,
+    );
+  }
+
+  /// Interpolates between two decoration token sets.
+  @override
+  AppDecorationTheme lerp(
+    covariant ThemeExtension<AppDecorationTheme>? other,
+    double t,
+  ) {
+    if (other is! AppDecorationTheme) {
+      return this;
+    }
+    return AppDecorationTheme(
+      radiusXs: lerpDouble(radiusXs, other.radiusXs, t) ?? other.radiusXs,
+      radiusSm: lerpDouble(radiusSm, other.radiusSm, t) ?? other.radiusSm,
+      radiusMd: lerpDouble(radiusMd, other.radiusMd, t) ?? other.radiusMd,
+      radiusLg: lerpDouble(radiusLg, other.radiusLg, t) ?? other.radiusLg,
+      radiusXl: lerpDouble(radiusXl, other.radiusXl, t) ?? other.radiusXl,
+      radiusPill:
+          lerpDouble(radiusPill, other.radiusPill, t) ?? other.radiusPill,
+      spaceXxs: lerpDouble(spaceXxs, other.spaceXxs, t) ?? other.spaceXxs,
+      spaceXs: lerpDouble(spaceXs, other.spaceXs, t) ?? other.spaceXs,
+      spaceSm: lerpDouble(spaceSm, other.spaceSm, t) ?? other.spaceSm,
+      spaceMd: lerpDouble(spaceMd, other.spaceMd, t) ?? other.spaceMd,
+      spaceLg: lerpDouble(spaceLg, other.spaceLg, t) ?? other.spaceLg,
+      spaceXl: lerpDouble(spaceXl, other.spaceXl, t) ?? other.spaceXl,
+      spaceXxl: lerpDouble(spaceXxl, other.spaceXxl, t) ?? other.spaceXxl,
+      screenPadding:
+          lerpDouble(screenPadding, other.screenPadding, t) ??
+          other.screenPadding,
+      buttonRadius:
+          lerpDouble(buttonRadius, other.buttonRadius, t) ?? other.buttonRadius,
+      inputRadius:
+          lerpDouble(inputRadius, other.inputRadius, t) ?? other.inputRadius,
+      chipRadius:
+          lerpDouble(chipRadius, other.chipRadius, t) ?? other.chipRadius,
+      buttonMinSize: Size.lerp(buttonMinSize, other.buttonMinSize, t)!,
+      buttonPadding: EdgeInsets.lerp(buttonPadding, other.buttonPadding, t)!,
+      inputPadding: EdgeInsets.lerp(inputPadding, other.inputPadding, t)!,
+      chipPadding: EdgeInsets.lerp(chipPadding, other.chipPadding, t)!,
+      borderThin:
+          lerpDouble(borderThin, other.borderThin, t) ?? other.borderThin,
+      borderRegular:
+          lerpDouble(borderRegular, other.borderRegular, t) ??
+          other.borderRegular,
+      elevationNone:
+          lerpDouble(elevationNone, other.elevationNone, t) ??
+          other.elevationNone,
+      elevationSm:
+          lerpDouble(elevationSm, other.elevationSm, t) ?? other.elevationSm,
+      elevationMd:
+          lerpDouble(elevationMd, other.elevationMd, t) ?? other.elevationMd,
+    );
+  }
+}

--- a/plugins/fl_theme/lib/src/app_design_system.dart
+++ b/plugins/fl_theme/lib/src/app_design_system.dart
@@ -1,0 +1,206 @@
+import 'package:flex_color_scheme/flex_color_scheme.dart';
+import 'package:flutter/material.dart';
+
+import 'app_component_theme.dart';
+import 'app_decoration_theme.dart';
+import 'app_text_theme.dart';
+import 'app_typography_theme.dart';
+import 'json/theme_json_color.dart';
+import 'json/theme_json_config.dart';
+import 'json/theme_json_screen.dart';
+import 'screen_theme.dart';
+import 'theme_color.dart';
+
+/// Groups the semantic theme pieces used to build an app [ThemeData].
+///
+/// `AppDesignSystem` is the preferred runtime configuration surface for
+/// `fl_theme`. It keeps semantic colors, screen chrome, typography, decoration
+/// tokens, component behavior, FlexColorScheme overrides, platform, Material 3,
+/// and font-family settings together so an app can create consistent light/dark
+/// themes from one object.
+///
+/// JSON import/export flows should use [AppDesignSystem.fromJsonConfig] and
+/// [toJsonConfig]. Direct app code can construct this class by hand when it
+/// needs callbacks, precomputed text themes, or FlexColorScheme-specific
+/// overrides that are intentionally not part of the portable JSON schema.
+class AppDesignSystem {
+  /// Human-readable name for this design system.
+  final String name;
+
+  /// Semantic colors exposed through [ThemeColorExtension].
+  final ThemeColor colors;
+
+  /// Screen chrome settings exposed through [ScreenTheme].
+  final ScreenTheme screenTheme;
+
+  /// Typography factory and text role overrides.
+  final AppTypographyTheme typography;
+
+  /// Optional precomputed app text theme for screen and Material text roles.
+  ///
+  /// Pass this when caller code has already created a text theme that should be
+  /// reused by both screen chrome and Material theme generation. When null,
+  /// [AppTheme.create] calls [typography.create] with [colors].
+  final AppTextTheme? textTheme;
+
+  /// Shared spacing, radius, elevation, and density tokens.
+  final AppDecorationTheme decoration;
+
+  /// Material component settings derived from design tokens.
+  final AppComponentTheme components;
+
+  /// Optional FlexColorScheme color data used instead of semantic colors.
+  ///
+  /// Use this for advanced FlexColorScheme palettes that cannot be represented
+  /// by the portable JSON color fields.
+  final FlexSchemeData? flexSchemeData;
+
+  /// Optional FlexColorScheme sub-theme data used instead of component tokens.
+  ///
+  /// Use this for advanced Material component tuning. When null, [components]
+  /// derives sub-theme data from [decoration] and [textTheme].
+  final FlexSubThemesData? flexSubThemesData;
+
+  /// Optional platform override for generated [ThemeData].
+  final TargetPlatform? targetPlatform;
+
+  /// Whether generated themes should use Material 3 defaults.
+  final bool useMaterial3;
+
+  /// Optional font family passed to FlexColorScheme.
+  final String? fontFamily;
+
+  /// Creates a complete design-system configuration.
+  ///
+  /// Only [colors] is required. Other parts default to conservative plugin
+  /// tokens, which lets apps start from a small semantic palette and then opt
+  /// into custom screen, typography, decoration, component, or Flex behavior.
+  const AppDesignSystem({
+    this.name = 'custom',
+    required this.colors,
+    this.screenTheme = const ScreenTheme(),
+    this.typography = const AppTypographyTheme(),
+    this.textTheme,
+    this.decoration = const AppDecorationTheme(),
+    this.components = const AppComponentTheme(),
+    this.flexSchemeData,
+    this.flexSubThemesData,
+    this.targetPlatform,
+    this.useMaterial3 = true,
+    this.fontFamily,
+  });
+
+  /// Creates a design system from a JSON theme configuration.
+  ///
+  /// This maps portable JSON DTO fields into runtime Flutter classes:
+  /// [ThemeJsonColor] becomes [ThemeColor], typography creates an
+  /// [AppTextTheme], decoration and component sections become their runtime
+  /// screen settings become [ScreenTheme].
+  factory AppDesignSystem.fromJsonConfig(ThemeJsonConfig config) {
+    final colors = ThemeColor(
+      primary: config.colors.primary,
+      secondary: config.colors.secondary,
+      surface: config.colors.surface,
+      background: config.colors.background,
+      error: config.colors.error,
+      brightness: config.mode,
+      appbarBackgroundColor: config.colors.appBarBackground,
+      appbarForegroundColor: config.colors.appBarForeground,
+      scaffoldBackgroundColor: config.colors.background,
+      cardBackground: config.colors.surface,
+      canvasColor: config.colors.surface,
+      elevatedBtnForegroundColor: config.mode == Brightness.light
+          ? Colors.white
+          : Colors.black,
+      outlineButtonColor: config.colors.primary,
+      labelText: config.mode == Brightness.light
+          ? const Color(0xFF6B7280)
+          : const Color(0xFFD1D5DB),
+    );
+    final typography = AppTypographyTheme.fromJsonConfig(config.typography);
+    final textTheme = typography.create(colors);
+
+    return AppDesignSystem(
+      name: config.name,
+      colors: colors,
+      screenTheme: ScreenTheme.fromTextTheme(
+        textTheme,
+        showHeaderImage: config.screen.showHeaderImage,
+        hasBottomBorderRadius: config.screen.hasBottomBorderRadius,
+        showAppbarDivider: config.screen.showAppbarDivider,
+        centerTitle: config.screen.centerTitle,
+      ),
+      typography: typography,
+      textTheme: textTheme,
+      decoration: AppDecorationTheme.fromJsonConfig(config.decoration),
+      components: AppComponentTheme.fromJsonConfig(config.components),
+      useMaterial3: config.useMaterial3,
+      fontFamily: config.fontFamily,
+    );
+  }
+
+  /// Converts this design system back to its JSON theme representation.
+  ///
+  /// Only portable values are included. Runtime-only callbacks, precomputed
+  /// [textTheme], platform overrides, and FlexColorScheme-specific overrides
+  /// are intentionally not serialized.
+  ThemeJsonConfig toJsonConfig() {
+    return ThemeJsonConfig(
+      name: name,
+      mode: colors.brightness,
+      useMaterial3: useMaterial3,
+      fontFamily: fontFamily,
+      colors: ThemeJsonColor(
+        primary: colors.primary,
+        secondary: colors.secondary,
+        surface: colors.surface,
+        background: colors.scaffoldBackgroundColor,
+        error: colors.error,
+        appBarBackground:
+            colors.appbarBackgroundColor ?? colors.scaffoldBackgroundColor,
+        appBarForeground: colors.appbarForegroundColor,
+      ),
+      typography: typography.toJsonConfig(),
+      decoration: decoration.toJsonConfig(),
+      components: components.toJsonConfig(),
+      screen: ThemeJsonScreen(
+        showHeaderImage: screenTheme.screenFormTheme.showHeaderImage,
+        hasBottomBorderRadius:
+            screenTheme.screenFormTheme.hasBottomBorderRadius,
+        showAppbarDivider: screenTheme.screenFormTheme.showAppbarDivider,
+        centerTitle: screenTheme.screenFormTheme.centerTitle,
+      ),
+    );
+  }
+
+  /// Creates a copy with selected design-system parts replaced.
+  AppDesignSystem copyWith({
+    String? name,
+    ThemeColor? colors,
+    ScreenTheme? screenTheme,
+    AppTypographyTheme? typography,
+    AppTextTheme? textTheme,
+    AppDecorationTheme? decoration,
+    AppComponentTheme? components,
+    FlexSchemeData? flexSchemeData,
+    FlexSubThemesData? flexSubThemesData,
+    TargetPlatform? targetPlatform,
+    bool? useMaterial3,
+    String? fontFamily,
+  }) {
+    return AppDesignSystem(
+      name: name ?? this.name,
+      colors: colors ?? this.colors,
+      screenTheme: screenTheme ?? this.screenTheme,
+      typography: typography ?? this.typography,
+      textTheme: textTheme ?? this.textTheme,
+      decoration: decoration ?? this.decoration,
+      components: components ?? this.components,
+      flexSchemeData: flexSchemeData ?? this.flexSchemeData,
+      flexSubThemesData: flexSubThemesData ?? this.flexSubThemesData,
+      targetPlatform: targetPlatform ?? this.targetPlatform,
+      useMaterial3: useMaterial3 ?? this.useMaterial3,
+      fontFamily: fontFamily ?? this.fontFamily,
+    );
+  }
+}

--- a/plugins/fl_theme/lib/src/app_text_theme.dart
+++ b/plugins/fl_theme/lib/src/app_text_theme.dart
@@ -2,6 +2,11 @@ import 'package:flutter/material.dart';
 
 import 'theme_color.dart';
 
+/// Semantic text role names exposed by [AppTextTheme].
+///
+/// The first values mirror Flutter's Material 3 [TextTheme] slots. The extra
+/// values at the end are app-specific roles for inputs, validation, helpers,
+/// and buttons.
 enum TextThemeStyle {
   /// Largest of the display styles.
   ///
@@ -57,6 +62,7 @@ enum TextThemeStyle {
   /// medium-emphasis text.
   titleSmall,
 
+  /// Extra-small title role used for dense labels and form metadata.
   titleTiny,
 
   /// Largest of the body styles.
@@ -99,17 +105,35 @@ enum TextThemeStyle {
   /// content body, like captions.
   labelSmall,
 
+  /// Text entered into input controls.
   textInput,
+
+  /// Labels and titles for input controls.
   inputTitle,
+
+  /// Required-field indicators and required helper text.
   inputRequired,
+
+  /// Placeholder and hint text inside input controls.
   inputHint,
+
+  /// Validation error text for input controls.
   inputError,
+
+  /// Text used by app button themes.
   buttonText,
 }
 
+/// Theme extension that stores the app semantic text theme in [ThemeData].
+///
+/// It is attached by [AppTheme] and read through `context.textTheme` so widgets
+/// can use app-specific roles without reaching into `Theme.of(context)`
+/// directly.
 class AppTextThemeExtension extends ThemeExtension<AppTextThemeExtension> {
+  /// Semantic text theme for app widgets and generated Material themes.
   final AppTextTheme textTheme;
 
+  /// Creates a text theme extension.
   AppTextThemeExtension({required this.textTheme});
 
   @override
@@ -125,6 +149,13 @@ class AppTextThemeExtension extends ThemeExtension<AppTextThemeExtension> {
   }
 }
 
+/// Material text theme with app-specific semantic text roles.
+///
+/// `AppTextTheme` keeps Flutter's Material 3 text slots and adds roles used by
+/// this template's inputs, helpers, validation messages, and button themes. It
+/// is generated from [ThemeColor] by [AppTextTheme.create], optionally
+/// adjusted by typography configuration, and attached to [ThemeData] with
+/// [AppTextThemeExtension].
 class AppTextTheme extends TextTheme {
   /// Default using [TextTheme.titleSmall] with 85% font size
   ///
@@ -155,6 +186,12 @@ class AppTextTheme extends TextTheme {
   /// with color is [Colors.red]
   final TextStyle? helper;
 
+  /// Creates an app text theme with Material and custom semantic roles.
+  ///
+  /// Any omitted custom role is derived from the closest Material text slot.
+  /// The generated defaults are useful when manually creating a theme, but most
+  /// apps should use [AppTextTheme.create] or [AppTypographyTheme.create] so
+  /// colors and role overrides stay consistent.
   AppTextTheme({
     super.displayLarge,
     super.displayMedium,
@@ -191,6 +228,11 @@ class AppTextTheme extends TextTheme {
        helper = helper ?? bodySmall,
        buttonText = buttonText ?? labelLarge;
 
+  /// Creates the default semantic text roles from [themeColor].
+  ///
+  /// The optional [wrapper] is applied to every base [TextStyle]. This is
+  /// useful for global font adapters because it runs before custom roles such
+  /// as [inputTitle] and [buttonText] are derived or overridden.
   factory AppTextTheme.create(
     ThemeColor themeColor, {
     TextStyle Function(TextStyle)? wrapper,
@@ -279,6 +321,7 @@ class AppTextTheme extends TextTheme {
     );
   }
 
+  /// Linearly interpolates every Material and custom text role.
   AppTextTheme lerp(AppTextTheme? other, double t) {
     return AppTextTheme(
       displayLarge: TextStyle.lerp(displayLarge, other?.displayLarge, t),
@@ -306,6 +349,10 @@ class AppTextTheme extends TextTheme {
     );
   }
 
+  /// Creates a copy with selected Material or custom text roles replaced.
+  ///
+  /// This method intentionally returns [AppTextTheme], unlike Flutter's base
+  /// `TextTheme.copyWith`, so custom roles remain available after overrides.
   AppTextTheme copyWithTypography({
     TextStyle? displayLarge,
     TextStyle? displayMedium,

--- a/plugins/fl_theme/lib/src/app_typography_theme.dart
+++ b/plugins/fl_theme/lib/src/app_typography_theme.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+
+import 'app_text_theme.dart';
+import 'json/theme_json_typography.dart';
+import 'theme_color.dart';
+
+/// Overrides an app text theme after token-based typography is applied.
+///
+/// Use this callback when an app needs to remap semantic roles, such as making
+/// `buttonText` use a different base slot, after the standard text styles and
+/// JSON typography fields have already been applied.
+typedef AppTextThemeOverride = AppTextTheme Function(AppTextTheme textTheme);
+
+/// Configures how semantic app text roles are created.
+///
+/// `AppTypographyTheme` is a factory configuration, not a [ThemeExtension]. It
+/// creates the [AppTextTheme] that is attached to [ThemeData] through
+/// [AppTextThemeExtension]. The [wrapper] is applied to every base style first,
+/// then JSON-style size/weight fields are applied, and finally [override] can
+/// replace any semantic role.
+class AppTypographyTheme {
+  /// Optional wrapper applied to every base text style.
+  ///
+  /// This is the right hook for font-family package adapters or global text
+  /// transforms because it runs before semantic roles are copied or overridden.
+  final TextStyle Function(TextStyle style)? wrapper;
+
+  /// Optional final override for the generated app text theme.
+  ///
+  /// This runs after [buttonFontSize], [buttonFontWeight], and [bodyFontSize]
+  /// have been applied.
+  final AppTextThemeOverride? override;
+
+  /// Optional font size for button text roles.
+  final double? buttonFontSize;
+
+  /// Optional font weight for button text roles.
+  final FontWeight? buttonFontWeight;
+
+  /// Optional font size for body and input title text roles.
+  final double? bodyFontSize;
+
+  /// Creates typography settings for generated app text themes.
+  const AppTypographyTheme({
+    this.wrapper,
+    this.override,
+    this.buttonFontSize,
+    this.buttonFontWeight,
+    this.bodyFontSize,
+  });
+
+  /// Creates typography settings from a JSON theme typography section.
+  factory AppTypographyTheme.fromJsonConfig(ThemeJsonTypography config) {
+    return AppTypographyTheme(
+      buttonFontSize: config.buttonFontSize,
+      buttonFontWeight: _fontWeightFromValue(config.buttonFontWeight),
+      bodyFontSize: config.bodyFontSize,
+    );
+  }
+
+  /// Creates semantic app text roles for the provided [colors].
+  AppTextTheme create(ThemeColor colors) {
+    final base = AppTextTheme.create(colors, wrapper: wrapper);
+    final configured = base.copyWithTypography(
+      bodyMedium: base.bodyMedium?.copyWith(fontSize: bodyFontSize),
+      inputTitle: base.bodyMedium?.copyWith(fontSize: bodyFontSize),
+      buttonText: base.buttonText?.copyWith(
+        fontSize: buttonFontSize,
+        fontWeight: buttonFontWeight,
+      ),
+    );
+    return override?.call(configured) ?? configured;
+  }
+
+  /// Converts these typography settings to their JSON DTO.
+  ThemeJsonTypography toJsonConfig() {
+    return ThemeJsonTypography(
+      buttonFontSize: buttonFontSize ?? 15,
+      buttonFontWeight: buttonFontWeight?.value ?? 600,
+      bodyFontSize: bodyFontSize ?? 14,
+    );
+  }
+
+  /// Creates a copy with selected typography settings replaced.
+  AppTypographyTheme copyWith({
+    TextStyle Function(TextStyle style)? wrapper,
+    AppTextThemeOverride? override,
+    double? buttonFontSize,
+    FontWeight? buttonFontWeight,
+    double? bodyFontSize,
+  }) {
+    return AppTypographyTheme(
+      wrapper: wrapper ?? this.wrapper,
+      override: override ?? this.override,
+      buttonFontSize: buttonFontSize ?? this.buttonFontSize,
+      buttonFontWeight: buttonFontWeight ?? this.buttonFontWeight,
+      bodyFontSize: bodyFontSize ?? this.bodyFontSize,
+    );
+  }
+
+  static FontWeight _fontWeightFromValue(int value) {
+    switch (value.clamp(100, 900)) {
+      case 100:
+        return FontWeight.w100;
+      case 200:
+        return FontWeight.w200;
+      case 300:
+        return FontWeight.w300;
+      case 400:
+        return FontWeight.w400;
+      case 500:
+        return FontWeight.w500;
+      case 700:
+        return FontWeight.w700;
+      case 800:
+        return FontWeight.w800;
+      case 900:
+        return FontWeight.w900;
+      case 600:
+      default:
+        return FontWeight.w600;
+    }
+  }
+}

--- a/plugins/fl_theme/lib/src/extension.dart
+++ b/plugins/fl_theme/lib/src/extension.dart
@@ -2,17 +2,33 @@ import 'package:flutter/material.dart';
 
 import '../fl_theme.dart';
 
+/// Convenience accessors for app theme extensions on [BuildContext].
+///
+/// These getters assume the nearest [ThemeData] was created by [AppTheme] or
+/// has equivalent extensions attached. Use them in `build` and
+/// `didChangeDependencies`, not before a widget has an inherited [Theme]
+/// ancestor.
 extension FLThemePresentationContextExt on BuildContext {
+  /// The nearest Material [ThemeData].
   ThemeData get theme => Theme.of(this);
 
+  /// The app semantic text theme extension.
   AppTextTheme get textTheme =>
       theme.extension<AppTextThemeExtension>()!.textTheme;
 
+  /// The app semantic color extension.
   ThemeColor get themeColor => theme.extension<ThemeColorExtension>()!.colors;
 
+  /// The app screen chrome theme extension.
   ScreenTheme get screenTheme => theme.extension<ScreenTheme>()!;
 
+  /// The screen form theme from [screenTheme].
   ScreenFormTheme get screenFormTheme => screenTheme.screenFormTheme;
 
+  /// The main page form theme from [screenTheme].
   MainPageFormTheme get mainPageFormTheme => screenTheme.mainPageFormTheme;
+
+  /// The app decoration token theme extension.
+  AppDecorationTheme get decorationTheme =>
+      theme.extension<AppDecorationTheme>()!;
 }

--- a/plugins/fl_theme/lib/src/json/theme_json_codec.dart
+++ b/plugins/fl_theme/lib/src/json/theme_json_codec.dart
@@ -1,0 +1,138 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+/// Decodes a JSON theme string into a map.
+Map<String, dynamic> decodeThemeJson(String source) {
+  final decoded = jsonDecode(source);
+  if (decoded is! Map<String, dynamic>) {
+    throw const FormatException('Theme JSON must be an object');
+  }
+  return decoded;
+}
+
+/// Encodes a JSON theme map with stable indentation.
+String encodeThemeJson(Map<String, dynamic> json) {
+  return const JsonEncoder.withIndent('  ').convert(json);
+}
+
+/// Reads an object value from [json] or returns [fallback] when absent.
+Map<String, dynamic> readObject(
+  Map<String, dynamic> json,
+  String key, {
+  Map<String, dynamic> fallback = const {},
+}) {
+  final value = json[key];
+  if (value == null) {
+    return fallback;
+  }
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+  if (value is Map) {
+    return value.map((key, value) => MapEntry(key.toString(), value));
+  }
+  throw FormatException('$key must be an object');
+}
+
+/// Reads a nullable string value from [json].
+String? readString(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value == null) {
+    return null;
+  }
+  if (value is String) {
+    return value;
+  }
+  throw FormatException('$key must be a string');
+}
+
+/// Reads a boolean value from [json] or returns [fallback] when absent.
+bool readBool(Map<String, dynamic> json, String key, bool fallback) {
+  final value = json[key];
+  if (value == null) {
+    return fallback;
+  }
+  if (value is bool) {
+    return value;
+  }
+  throw FormatException('$key must be a boolean');
+}
+
+/// Reads an integer value from [json] or returns [fallback] when absent.
+int readInt(Map<String, dynamic> json, String key, int fallback) {
+  final value = json[key];
+  if (value == null) {
+    return fallback;
+  }
+  if (value is int) {
+    return value;
+  }
+  if (value is num) {
+    return value.round();
+  }
+  throw FormatException('$key must be a number');
+}
+
+/// Reads a double value from [json] or returns [fallback] when absent.
+double readDouble(Map<String, dynamic> json, String key, double fallback) {
+  final value = json[key];
+  if (value == null) {
+    return fallback;
+  }
+  if (value is num) {
+    return value.toDouble();
+  }
+  throw FormatException('$key must be a number');
+}
+
+/// Reads a hex color string from [json] or returns [fallback] when absent.
+Color readColor(
+  Map<String, dynamic> json,
+  String key,
+  Color fallback, {
+  String? path,
+}) {
+  final value = json[key];
+  final errorPath = path ?? key;
+  if (value == null) {
+    return fallback;
+  }
+  if (value is! String) {
+    throw FormatException('$errorPath must be a hex color string');
+  }
+  return themeColorFromHex(value, path: errorPath);
+}
+
+/// Parses a `#RRGGBB` or `#AARRGGBB` string into a Flutter [Color].
+Color themeColorFromHex(String value, {String path = 'color'}) {
+  final normalized = value.trim().replaceFirst('#', '');
+  final hex = normalized.length == 6 ? 'FF$normalized' : normalized;
+  if (hex.length != 8 || !RegExp(r'^[0-9A-Fa-f]{8}$').hasMatch(hex)) {
+    throw FormatException('$path must be #RRGGBB or #AARRGGBB');
+  }
+  return Color(int.parse(hex, radix: 16));
+}
+
+/// Encodes a Flutter [Color] as an uppercase `#AARRGGBB` string.
+String themeColorToHex(Color color) {
+  final value = color.toARGB32().toRadixString(16).padLeft(8, '0');
+  return '#${value.toUpperCase()}';
+}
+
+/// Parses a JSON theme mode string into a Flutter [Brightness].
+Brightness brightnessFromJson(String? value) {
+  switch (value) {
+    case null:
+    case 'light':
+      return Brightness.light;
+    case 'dark':
+      return Brightness.dark;
+  }
+  throw const FormatException('mode must be light or dark');
+}
+
+/// Encodes a Flutter [Brightness] as a JSON theme mode string.
+String brightnessToJson(Brightness brightness) {
+  return brightness.name;
+}

--- a/plugins/fl_theme/lib/src/json/theme_json_color.dart
+++ b/plugins/fl_theme/lib/src/json/theme_json_color.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+
+import 'theme_json_codec.dart';
+
+/// JSON DTO for the semantic color section of a theme config.
+class ThemeJsonColor {
+  /// Primary brand color.
+  final Color primary;
+
+  /// Secondary brand or accent color.
+  final Color secondary;
+
+  /// Surface color for cards, sheets, and elevated content.
+  final Color surface;
+
+  /// Background color for scaffolds and scrollable content.
+  final Color background;
+
+  /// Error color for validation and destructive states.
+  final Color error;
+
+  /// App bar background color.
+  final Color appBarBackground;
+
+  /// App bar foreground color.
+  final Color appBarForeground;
+
+  /// Creates a JSON color DTO with light-theme defaults.
+  const ThemeJsonColor({
+    this.primary = const Color(0xFF3B82F6),
+    this.secondary = const Color(0xFFEFF6FF),
+    this.surface = Colors.white,
+    this.background = const Color(0xFFF3F4F6),
+    this.error = const Color(0xFFB00020),
+    this.appBarBackground = Colors.white,
+    this.appBarForeground = const Color(0xFF111827),
+  });
+
+  /// Creates colors from a JSON object using brightness-aware fallbacks.
+  factory ThemeJsonColor.fromJson(
+    Map<String, dynamic> json, {
+    Brightness brightness = Brightness.light,
+  }) {
+    final fallback = brightness == Brightness.light
+        ? const ThemeJsonColor()
+        : const ThemeJsonColor(
+            surface: Color(0xFF121212),
+            background: Color(0xFF111827),
+            error: Color(0xFFCF6679),
+            appBarBackground: Color(0xFF111827),
+            appBarForeground: Colors.white,
+          );
+
+    return ThemeJsonColor(
+      primary: readColor(
+        json,
+        'primary',
+        fallback.primary,
+        path: 'colors.primary',
+      ),
+      secondary: readColor(
+        json,
+        'secondary',
+        fallback.secondary,
+        path: 'colors.secondary',
+      ),
+      surface: readColor(
+        json,
+        'surface',
+        fallback.surface,
+        path: 'colors.surface',
+      ),
+      background: readColor(
+        json,
+        'background',
+        fallback.background,
+        path: 'colors.background',
+      ),
+      error: readColor(json, 'error', fallback.error, path: 'colors.error'),
+      appBarBackground: readColor(
+        json,
+        'appBarBackground',
+        fallback.appBarBackground,
+        path: 'colors.appBarBackground',
+      ),
+      appBarForeground: readColor(
+        json,
+        'appBarForeground',
+        fallback.appBarForeground,
+        path: 'colors.appBarForeground',
+      ),
+    );
+  }
+
+  /// Converts colors to JSON using uppercase hex strings.
+  Map<String, dynamic> toJson() {
+    return {
+      'primary': themeColorToHex(primary),
+      'secondary': themeColorToHex(secondary),
+      'surface': themeColorToHex(surface),
+      'background': themeColorToHex(background),
+      'error': themeColorToHex(error),
+      'appBarBackground': themeColorToHex(appBarBackground),
+      'appBarForeground': themeColorToHex(appBarForeground),
+    };
+  }
+
+  /// Creates a copy with selected colors replaced.
+  ThemeJsonColor copyWith({
+    Color? primary,
+    Color? secondary,
+    Color? surface,
+    Color? background,
+    Color? error,
+    Color? appBarBackground,
+    Color? appBarForeground,
+  }) {
+    return ThemeJsonColor(
+      primary: primary ?? this.primary,
+      secondary: secondary ?? this.secondary,
+      surface: surface ?? this.surface,
+      background: background ?? this.background,
+      error: error ?? this.error,
+      appBarBackground: appBarBackground ?? this.appBarBackground,
+      appBarForeground: appBarForeground ?? this.appBarForeground,
+    );
+  }
+}

--- a/plugins/fl_theme/lib/src/json/theme_json_component.dart
+++ b/plugins/fl_theme/lib/src/json/theme_json_component.dart
@@ -1,0 +1,51 @@
+import 'theme_json_codec.dart';
+
+/// JSON DTO for component behavior in a theme config.
+class ThemeJsonComponent {
+  /// Whether input decorations should render with a filled background.
+  final bool inputFilled;
+
+  /// Whether app bar titles should be centered by default.
+  final bool appBarCenterTitle;
+
+  /// Whether selectable chips should show Material checkmarks.
+  final bool chipShowCheckmark;
+
+  /// Creates a component JSON DTO with default Material behavior.
+  const ThemeJsonComponent({
+    this.inputFilled = false,
+    this.appBarCenterTitle = true,
+    this.chipShowCheckmark = true,
+  });
+
+  /// Creates component settings from a JSON object.
+  factory ThemeJsonComponent.fromJson(Map<String, dynamic> json) {
+    return ThemeJsonComponent(
+      inputFilled: readBool(json, 'inputFilled', false),
+      appBarCenterTitle: readBool(json, 'appBarCenterTitle', true),
+      chipShowCheckmark: readBool(json, 'chipShowCheckmark', true),
+    );
+  }
+
+  /// Converts component settings to JSON.
+  Map<String, dynamic> toJson() {
+    return {
+      'inputFilled': inputFilled,
+      'appBarCenterTitle': appBarCenterTitle,
+      'chipShowCheckmark': chipShowCheckmark,
+    };
+  }
+
+  /// Creates a copy with selected component settings replaced.
+  ThemeJsonComponent copyWith({
+    bool? inputFilled,
+    bool? appBarCenterTitle,
+    bool? chipShowCheckmark,
+  }) {
+    return ThemeJsonComponent(
+      inputFilled: inputFilled ?? this.inputFilled,
+      appBarCenterTitle: appBarCenterTitle ?? this.appBarCenterTitle,
+      chipShowCheckmark: chipShowCheckmark ?? this.chipShowCheckmark,
+    );
+  }
+}

--- a/plugins/fl_theme/lib/src/json/theme_json_config.dart
+++ b/plugins/fl_theme/lib/src/json/theme_json_config.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+
+import 'theme_json_codec.dart';
+import 'theme_json_color.dart';
+import 'theme_json_component.dart';
+import 'theme_json_decoration.dart';
+import 'theme_json_screen.dart';
+import 'theme_json_typography.dart';
+
+/// Root JSON DTO for importing and exporting app theme configuration.
+class ThemeJsonConfig {
+  /// Version of the JSON schema used by this config.
+  final int schemaVersion;
+
+  /// Human-readable theme name.
+  final String name;
+
+  /// Theme brightness mode.
+  final Brightness mode;
+
+  /// Whether generated themes should use Material 3 defaults.
+  final bool useMaterial3;
+
+  /// Optional font family for generated themes.
+  final String? fontFamily;
+
+  /// Semantic color configuration.
+  final ThemeJsonColor colors;
+
+  /// Typography role configuration.
+  final ThemeJsonTypography typography;
+
+  /// Decoration token configuration.
+  final ThemeJsonDecoration decoration;
+
+  /// Material component behavior configuration.
+  final ThemeJsonComponent components;
+
+  /// Project screen chrome configuration.
+  final ThemeJsonScreen screen;
+
+  /// Creates a complete JSON theme configuration.
+  const ThemeJsonConfig({
+    this.schemaVersion = 1,
+    this.name = 'Ocean Blue',
+    this.mode = Brightness.light,
+    this.useMaterial3 = true,
+    this.fontFamily,
+    this.colors = const ThemeJsonColor(),
+    this.typography = const ThemeJsonTypography(),
+    this.decoration = const ThemeJsonDecoration(),
+    this.components = const ThemeJsonComponent(),
+    this.screen = const ThemeJsonScreen(),
+  });
+
+  /// Creates a theme configuration from a decoded JSON object.
+  factory ThemeJsonConfig.fromJson(Map<String, dynamic> json) {
+    final mode = brightnessFromJson(readString(json, 'mode'));
+    return ThemeJsonConfig(
+      schemaVersion: readInt(json, 'schemaVersion', 1),
+      name: readString(json, 'name') ?? 'Custom Theme',
+      mode: mode,
+      useMaterial3: readBool(json, 'useMaterial3', true),
+      fontFamily: readString(json, 'fontFamily'),
+      colors: ThemeJsonColor.fromJson(
+        readObject(json, 'colors'),
+        brightness: mode,
+      ),
+      typography: ThemeJsonTypography.fromJson(readObject(json, 'typography')),
+      decoration: ThemeJsonDecoration.fromJson(readObject(json, 'decoration')),
+      components: ThemeJsonComponent.fromJson(readObject(json, 'components')),
+      screen: ThemeJsonScreen.fromJson(readObject(json, 'screen')),
+    );
+  }
+
+  /// Decodes a JSON string into a theme configuration.
+  factory ThemeJsonConfig.decode(String source) {
+    return ThemeJsonConfig.fromJson(decodeThemeJson(source));
+  }
+
+  /// Converts this theme configuration to a JSON object.
+  Map<String, dynamic> toJson() {
+    return {
+      'schemaVersion': schemaVersion,
+      'name': name,
+      'mode': brightnessToJson(mode),
+      'useMaterial3': useMaterial3,
+      'fontFamily': fontFamily,
+      'colors': colors.toJson(),
+      'typography': typography.toJson(),
+      'decoration': decoration.toJson(),
+      'components': components.toJson(),
+      'screen': screen.toJson(),
+    };
+  }
+
+  /// Encodes this theme configuration as formatted JSON.
+  String encode() {
+    return encodeThemeJson(toJson());
+  }
+
+  /// Creates a copy with selected theme configuration values replaced.
+  ThemeJsonConfig copyWith({
+    int? schemaVersion,
+    String? name,
+    Brightness? mode,
+    bool? useMaterial3,
+    String? fontFamily,
+    bool includeFontFamily = false,
+    ThemeJsonColor? colors,
+    ThemeJsonTypography? typography,
+    ThemeJsonDecoration? decoration,
+    ThemeJsonComponent? components,
+    ThemeJsonScreen? screen,
+  }) {
+    return ThemeJsonConfig(
+      schemaVersion: schemaVersion ?? this.schemaVersion,
+      name: name ?? this.name,
+      mode: mode ?? this.mode,
+      useMaterial3: useMaterial3 ?? this.useMaterial3,
+      fontFamily: includeFontFamily
+          ? fontFamily
+          : fontFamily ?? this.fontFamily,
+      colors: colors ?? this.colors,
+      typography: typography ?? this.typography,
+      decoration: decoration ?? this.decoration,
+      components: components ?? this.components,
+      screen: screen ?? this.screen,
+    );
+  }
+}

--- a/plugins/fl_theme/lib/src/json/theme_json_decoration.dart
+++ b/plugins/fl_theme/lib/src/json/theme_json_decoration.dart
@@ -1,0 +1,67 @@
+import 'theme_json_codec.dart';
+
+/// JSON DTO for decoration tokens in a theme config.
+class ThemeJsonDecoration {
+  /// Base corner radius used to derive the runtime radius scale.
+  final double radius;
+
+  /// Corner radius intended for buttons.
+  final double buttonRadius;
+
+  /// Corner radius intended for input fields.
+  final double inputRadius;
+
+  /// Corner radius intended for chips.
+  final double chipRadius;
+
+  /// Base screen padding used to derive the runtime spacing scale.
+  final double screenPadding;
+
+  /// Creates a decoration JSON DTO with default spacing and radius values.
+  const ThemeJsonDecoration({
+    this.radius = 8,
+    this.buttonRadius = 8,
+    this.inputRadius = 8,
+    this.chipRadius = 16,
+    this.screenPadding = 16,
+  });
+
+  /// Creates decoration tokens from a JSON object.
+  factory ThemeJsonDecoration.fromJson(Map<String, dynamic> json) {
+    return ThemeJsonDecoration(
+      radius: readDouble(json, 'radius', 8),
+      buttonRadius: readDouble(json, 'buttonRadius', 8),
+      inputRadius: readDouble(json, 'inputRadius', 8),
+      chipRadius: readDouble(json, 'chipRadius', 16),
+      screenPadding: readDouble(json, 'screenPadding', 16),
+    );
+  }
+
+  /// Converts decoration tokens to JSON.
+  Map<String, dynamic> toJson() {
+    return {
+      'radius': radius,
+      'buttonRadius': buttonRadius,
+      'inputRadius': inputRadius,
+      'chipRadius': chipRadius,
+      'screenPadding': screenPadding,
+    };
+  }
+
+  /// Creates a copy with selected decoration tokens replaced.
+  ThemeJsonDecoration copyWith({
+    double? radius,
+    double? buttonRadius,
+    double? inputRadius,
+    double? chipRadius,
+    double? screenPadding,
+  }) {
+    return ThemeJsonDecoration(
+      radius: radius ?? this.radius,
+      buttonRadius: buttonRadius ?? this.buttonRadius,
+      inputRadius: inputRadius ?? this.inputRadius,
+      chipRadius: chipRadius ?? this.chipRadius,
+      screenPadding: screenPadding ?? this.screenPadding,
+    );
+  }
+}

--- a/plugins/fl_theme/lib/src/json/theme_json_screen.dart
+++ b/plugins/fl_theme/lib/src/json/theme_json_screen.dart
@@ -1,0 +1,60 @@
+import 'theme_json_codec.dart';
+
+/// JSON DTO for project screen chrome settings in a theme config.
+class ThemeJsonScreen {
+  /// Whether screen forms should display their header image.
+  final bool showHeaderImage;
+
+  /// Whether screen forms should round their bottom edge.
+  final bool hasBottomBorderRadius;
+
+  /// Whether app bars should show a bottom divider.
+  final bool showAppbarDivider;
+
+  /// Whether screen titles should be centered.
+  final bool centerTitle;
+
+  /// Creates a screen JSON DTO with default screen chrome values.
+  const ThemeJsonScreen({
+    this.showHeaderImage = false,
+    this.hasBottomBorderRadius = false,
+    this.showAppbarDivider = false,
+    this.centerTitle = false,
+  });
+
+  /// Creates screen chrome settings from a JSON object.
+  factory ThemeJsonScreen.fromJson(Map<String, dynamic> json) {
+    return ThemeJsonScreen(
+      showHeaderImage: readBool(json, 'showHeaderImage', false),
+      hasBottomBorderRadius: readBool(json, 'hasBottomBorderRadius', false),
+      showAppbarDivider: readBool(json, 'showAppbarDivider', false),
+      centerTitle: readBool(json, 'centerTitle', false),
+    );
+  }
+
+  /// Converts screen chrome settings to JSON.
+  Map<String, dynamic> toJson() {
+    return {
+      'showHeaderImage': showHeaderImage,
+      'hasBottomBorderRadius': hasBottomBorderRadius,
+      'showAppbarDivider': showAppbarDivider,
+      'centerTitle': centerTitle,
+    };
+  }
+
+  /// Creates a copy with selected screen chrome settings replaced.
+  ThemeJsonScreen copyWith({
+    bool? showHeaderImage,
+    bool? hasBottomBorderRadius,
+    bool? showAppbarDivider,
+    bool? centerTitle,
+  }) {
+    return ThemeJsonScreen(
+      showHeaderImage: showHeaderImage ?? this.showHeaderImage,
+      hasBottomBorderRadius:
+          hasBottomBorderRadius ?? this.hasBottomBorderRadius,
+      showAppbarDivider: showAppbarDivider ?? this.showAppbarDivider,
+      centerTitle: centerTitle ?? this.centerTitle,
+    );
+  }
+}

--- a/plugins/fl_theme/lib/src/json/theme_json_typography.dart
+++ b/plugins/fl_theme/lib/src/json/theme_json_typography.dart
@@ -1,0 +1,51 @@
+import 'theme_json_codec.dart';
+
+/// JSON DTO for typography settings in a theme config.
+class ThemeJsonTypography {
+  /// Font size for button text roles.
+  final double buttonFontSize;
+
+  /// Numeric font weight for button text roles.
+  final int buttonFontWeight;
+
+  /// Font size for body and input title text roles.
+  final double bodyFontSize;
+
+  /// Creates a typography JSON DTO with default text values.
+  const ThemeJsonTypography({
+    this.buttonFontSize = 15,
+    this.buttonFontWeight = 600,
+    this.bodyFontSize = 14,
+  });
+
+  /// Creates typography settings from a JSON object.
+  factory ThemeJsonTypography.fromJson(Map<String, dynamic> json) {
+    return ThemeJsonTypography(
+      buttonFontSize: readDouble(json, 'buttonFontSize', 15),
+      buttonFontWeight: readInt(json, 'buttonFontWeight', 600),
+      bodyFontSize: readDouble(json, 'bodyFontSize', 14),
+    );
+  }
+
+  /// Converts typography settings to JSON.
+  Map<String, dynamic> toJson() {
+    return {
+      'buttonFontSize': buttonFontSize,
+      'buttonFontWeight': buttonFontWeight,
+      'bodyFontSize': bodyFontSize,
+    };
+  }
+
+  /// Creates a copy with selected typography settings replaced.
+  ThemeJsonTypography copyWith({
+    double? buttonFontSize,
+    int? buttonFontWeight,
+    double? bodyFontSize,
+  }) {
+    return ThemeJsonTypography(
+      buttonFontSize: buttonFontSize ?? this.buttonFontSize,
+      buttonFontWeight: buttonFontWeight ?? this.buttonFontWeight,
+      bodyFontSize: bodyFontSize ?? this.bodyFontSize,
+    );
+  }
+}

--- a/plugins/fl_theme/lib/src/screen_theme.dart
+++ b/plugins/fl_theme/lib/src/screen_theme.dart
@@ -1,17 +1,58 @@
-// ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
+import 'app_text_theme.dart';
+
+/// Theme extension for project screen chrome defaults.
+///
+/// `ScreenTheme` is attached to generated [ThemeData] by [AppTheme] and read
+/// through `context.screenTheme`, `context.screenFormTheme`, and
+/// `context.mainPageFormTheme`. It keeps the reusable screen wrappers aligned
+/// with the same colors and typography as the Material theme.
 class ScreenTheme extends ThemeExtension<ScreenTheme> {
+  /// Defaults used by standard detail/form screens.
   final ScreenFormTheme screenFormTheme;
+
+  /// Defaults used by main-tab or top-level pages.
   final MainPageFormTheme mainPageFormTheme;
 
+  /// Creates screen chrome defaults for app wrappers.
   const ScreenTheme({
     this.screenFormTheme = const ScreenFormTheme(),
     this.mainPageFormTheme = const MainPageFormTheme(),
   });
 
+  /// Creates matching screen form themes from semantic app text roles.
+  ///
+  /// This is the preferred factory when building a theme from JSON or app
+  /// palette code because it applies the same title style to both screen
+  /// wrapper types and maps screen chrome flags into the runtime theme.
+  factory ScreenTheme.fromTextTheme(
+    AppTextTheme textTheme, {
+    bool showHeaderImage = false,
+    bool hasBottomBorderRadius = false,
+    bool showAppbarDivider = false,
+    bool centerTitle = false,
+  }) {
+    return ScreenTheme(
+      screenFormTheme: ScreenFormTheme(
+        showHeaderImage: showHeaderImage,
+        hasBottomBorderRadius: hasBottomBorderRadius,
+        showAppbarDivider: showAppbarDivider,
+        centerTitle: centerTitle,
+        titleStyle: textTheme.bodyLarge,
+      ),
+      mainPageFormTheme: MainPageFormTheme(
+        showHeaderImage: showHeaderImage,
+        hasBottomBorderRadius: hasBottomBorderRadius,
+        showAppbarDivider: showAppbarDivider,
+        titleStyle: textTheme.bodyLarge,
+      ),
+    );
+  }
+
+  /// Creates a copy with selected screen wrapper themes replaced.
   @override
   ScreenTheme copyWith({
     ScreenFormTheme? screenFormTheme,
@@ -23,6 +64,7 @@ class ScreenTheme extends ThemeExtension<ScreenTheme> {
     );
   }
 
+  /// Interpolates nested screen wrapper themes during theme changes.
   @override
   ScreenTheme lerp(covariant ScreenTheme? other, double t) {
     if (other == null) {
@@ -37,12 +79,29 @@ class ScreenTheme extends ThemeExtension<ScreenTheme> {
 
 const _kDefaultBackButtonSize = 22.0;
 
+/// Visual defaults for standard screen-form wrappers.
+///
+/// `ScreenFormTheme` configures app bar chrome, header treatment, title layout,
+/// and back-button presentation for reusable screen wrappers such as
+/// `ScreenForm`.
 class ScreenFormTheme {
+  /// Whether the wrapper should render its configured header image.
   final bool showHeaderImage;
+
+  /// Whether the wrapper should show a back button when navigation allows it.
   final bool showBackButton;
+
+  /// Whether the wrapper should round the bottom edge of the header/app bar.
   final bool hasBottomBorderRadius;
+
+  /// Whether the app bar title should be centered by default.
   final bool centerTitle;
+
+  /// Whether a divider should be drawn below the app bar.
   final bool showAppbarDivider;
+
+  /// Whether title centering should be enforced even when leading/actions
+  /// exist.
   final bool forceCenterTitle;
 
   /// default is [ThemeColor.appbarBackgroundColor]
@@ -50,6 +109,8 @@ class ScreenFormTheme {
 
   /// default is [ThemeColor.appbarForegroundColor]
   final Color? appbarForegroundColor;
+
+  /// Maximum number of app bar title lines.
   final int? titleMaxLines;
 
   /// Asset path for the back button icon (e.g. 'assets/icons/back.png').
@@ -68,6 +129,7 @@ class ScreenFormTheme {
   /// Optional spacing between the leading widget and the title in the AppBar.
   final double? titleSpacing;
 
+  /// Creates visual defaults for standard screen-form wrappers.
   const ScreenFormTheme({
     this.showHeaderImage = false,
     this.showBackButton = true,
@@ -85,6 +147,7 @@ class ScreenFormTheme {
     this.titleSpacing,
   });
 
+  /// Creates a copy with selected screen-form values replaced.
   ScreenFormTheme copyWith({
     bool? showHeaderImage,
     bool? showBackButton,
@@ -121,6 +184,7 @@ class ScreenFormTheme {
     );
   }
 
+  /// Interpolates colors, text styles, spacing, and animated numeric values.
   ScreenFormTheme lerp(covariant ScreenFormTheme? other, double t) {
     if (other == null) {
       return copyWith();
@@ -150,9 +214,18 @@ class ScreenFormTheme {
   }
 }
 
+/// Visual defaults for top-level or main-page wrappers.
+///
+/// `MainPageFormTheme` mirrors the screen-form chrome that main-tab pages need,
+/// without back-button or description styling concerns.
 class MainPageFormTheme {
+  /// Whether the wrapper should render its configured header image.
   final bool showHeaderImage;
+
+  /// Whether the header should draw an elevation/shadow treatment.
   final bool showHeaderShadow;
+
+  /// Whether the header should round its bottom edge.
   final bool hasBottomBorderRadius;
 
   /// default is [ThemeColor.primary]
@@ -160,12 +233,17 @@ class MainPageFormTheme {
 
   /// default is [ThemeColor.appbarForegroundColor]
   final Color? appbarForegroundColor;
+
+  /// Maximum number of app bar title lines.
   final int? titleMaxLines;
+
+  /// Whether a divider should be drawn below the app bar.
   final bool showAppbarDivider;
 
   /// default is [TextTheme.titleLarge]
   final TextStyle? titleStyle;
 
+  /// Creates visual defaults for top-level or main-page wrappers.
   const MainPageFormTheme({
     this.showHeaderImage = true,
     this.showHeaderShadow = true,
@@ -177,6 +255,7 @@ class MainPageFormTheme {
     this.titleStyle,
   });
 
+  /// Creates a copy with selected main-page values replaced.
   MainPageFormTheme copyWith({
     bool? showHeaderImage,
     bool? showHeaderShadow,
@@ -201,6 +280,7 @@ class MainPageFormTheme {
     );
   }
 
+  /// Interpolates colors, text style, and animated numeric values.
   MainPageFormTheme lerp(covariant MainPageFormTheme? other, double t) {
     if (other == null) {
       return copyWith();

--- a/plugins/fl_theme/lib/src/theme_color.dart
+++ b/plugins/fl_theme/lib/src/theme_color.dart
@@ -3,6 +3,14 @@ import 'package:flutter/services.dart';
 
 import 'utils/extension.dart';
 
+/// Semantic color palette used by `fl_theme` and app widgets.
+///
+/// `ThemeColor` is the color source for generated Material [ThemeData],
+/// FlexColorScheme input colors, and the `context.themeColor` extension. Apps
+/// usually provide only [primary], [secondary], and [brightness]; the
+/// constructor derives sensible Material scheme colors, surfaces, component
+/// state colors, and semantic text colors from those values. Override
+/// individual brand tokens when needed.
 class ThemeColor {
   /// Override [ThemeData.primaryColor].
   ///
@@ -200,16 +208,37 @@ class ThemeColor {
   /// Color of delete icon in chip
   final Color deleteIconColor;
 
+  /// Brightness that selects light or dark fallback values.
   final Brightness brightness;
-  // Text Color
+
+  /// Semantic color for display text roles.
   final Color displayText;
+
+  /// Semantic color for headline text roles.
   final Color headlineText;
+
+  /// Semantic color for title text roles.
   final Color titleText;
+
+  /// Semantic color for body text roles.
   final Color bodyText;
+
+  /// Semantic color for label text roles.
   final Color labelText;
+
+  /// Semantic color for warning text.
   final Color warningText;
+
+  /// Semantic color for links.
   final Color hyperLink;
 
+  /// Creates a semantic palette with brightness-aware fallback tokens.
+  ///
+  /// Required [primary], [secondary], and [brightness] define the brand and
+  /// mode. All other values are optional overrides. When omitted, colors are
+  /// derived from Material defaults, the brand colors, or light/dark fallback
+  /// surfaces so `AppTheme.create` can build a complete theme from a small
+  /// palette.
   ThemeColor({
     required this.primary,
     required this.secondary,
@@ -417,7 +446,7 @@ class ThemeColor {
        selectedLabelColor = selectedLabelColor ?? primary,
        selected = selected ?? primary;
 
-  //HEX code color
+  /// Legacy convenience swatches kept for existing app widgets.
   final lightGrey = const Color(0xFFbebebe);
   final greyDC = const Color(0xFFdcdcdc);
   final black = const Color(0xFF000000);
@@ -445,6 +474,7 @@ class ThemeColor {
   final lightGreen = const Color(0xFFE7F6E9);
   final green33B64F = const Color(0xFF33B64F);
 
+  /// Applies transparent light-theme status bar styling to the platform chrome.
   void setLightStatusBar() {
     SystemChrome.setSystemUIOverlayStyle(
       const SystemUiOverlayStyle(
@@ -455,6 +485,7 @@ class ThemeColor {
     );
   }
 
+  /// Applies transparent dark-theme status bar styling to the platform chrome.
   void setDarkStatusBar() {
     SystemChrome.setSystemUIOverlayStyle(
       const SystemUiOverlayStyle(
@@ -465,6 +496,7 @@ class ThemeColor {
     );
   }
 
+  /// Linearly interpolates semantic colors that participate in theme changes.
   ThemeColor lerp(covariant ThemeColor other, double t) {
     return ThemeColor(
       primary: Color.lerp(primary, other.primary, t) ?? other.primary,
@@ -576,6 +608,7 @@ class ThemeColor {
     );
   }
 
+  /// Two-layer soft shadow used by elevated custom surfaces.
   List<BoxShadow> get boxShadowBlur => [
     BoxShadow(
       offset: const Offset(0, 2),
@@ -589,19 +622,26 @@ class ThemeColor {
     ),
   ];
 
+  /// Lightest reusable shadow preset.
   List<BoxShadow> get boxShadowLightest => [
     BoxShadow(blurRadius: 1.5, color: shadowColor),
     BoxShadow(blurRadius: 1, color: shadowColor),
   ];
+
+  /// Light reusable shadow preset.
   List<BoxShadow> get boxShadowLight => [
     BoxShadow(blurRadius: 4, color: shadowColor),
     BoxShadow(blurRadius: 4, color: shadowColor),
   ];
+
+  /// Medium reusable shadow preset.
   List<BoxShadow> get boxShadowMedium => [
     ...boxShadowLight,
     BoxShadow(blurRadius: 8, color: shadowColor),
     BoxShadow(blurRadius: 8, color: shadowColor),
   ];
+
+  /// Strong reusable shadow preset.
   List<BoxShadow> get boxShadowDark => [
     ...boxShadowMedium,
     BoxShadow(blurRadius: 10.9, color: shadowColor),
@@ -609,9 +649,16 @@ class ThemeColor {
   ];
 }
 
+/// Theme extension that stores [ThemeColor] in [ThemeData].
+///
+/// It is attached by [AppTheme] and read through `context.themeColor`, giving
+/// widgets access to semantic colors without depending on raw Material palette
+/// slots.
 class ThemeColorExtension extends ThemeExtension<ThemeColorExtension> {
+  /// Semantic colors for the current theme.
   final ThemeColor colors;
 
+  /// Creates a semantic color extension.
   ThemeColorExtension({required this.colors});
 
   @override
@@ -624,7 +671,6 @@ class ThemeColorExtension extends ThemeExtension<ThemeColorExtension> {
     if (other == null) {
       return this;
     }
-    // improve handle lerp to using switch color animation
     return ThemeColorExtension(colors: colors.lerp(other.colors, t));
   }
 }

--- a/plugins/fl_theme/lib/src/theme_data.dart
+++ b/plugins/fl_theme/lib/src/theme_data.dart
@@ -1,119 +1,143 @@
+import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 
+import 'app_component_theme.dart';
+import 'app_decoration_theme.dart';
+import 'app_design_system.dart';
 import 'app_text_theme.dart';
+import 'app_typography_theme.dart';
 import 'screen_theme.dart';
 import 'theme_color.dart';
 
-/// Type definitions for theme component builders
+/// Builds a legacy [InputDecorationTheme] from semantic colors and text roles.
+///
+/// Prefer configuring [AppDesignSystem.components] and
+/// [AppDesignSystem.decoration] for new code. This callback remains for callers
+/// still using [AppTheme.factory] or legacy [AppThemeConfig] fields.
 typedef InputDecorationThemeBuilder =
     InputDecorationTheme Function({
       required ThemeColor themeColor,
       required AppTextTheme appTextTheme,
     });
 
+/// Builds a legacy [TextButtonThemeData] from semantic colors and text roles.
 typedef TextButtonThemeBuilder =
     TextButtonThemeData Function({
       required AppTextTheme textTheme,
       required ThemeColor themeColor,
     });
 
+/// Builds a legacy [ElevatedButtonThemeData] from semantic colors and text
+/// roles.
 typedef ElevatedButtonThemeBuilder =
     ElevatedButtonThemeData Function({
       required ThemeColor themeColor,
       required AppTextTheme textTheme,
     });
 
+/// Builds a legacy [OutlinedButtonThemeData] from semantic colors and text
+/// roles.
 typedef OutlinedButtonThemeBuilder =
     OutlinedButtonThemeData Function({
       required ThemeColor themeColor,
       required AppTextTheme textTheme,
     });
 
+/// Builds a legacy [TabBarThemeData] from semantic colors and text roles.
 typedef TabBarThemeBuilder =
     TabBarThemeData Function({
       required AppTextTheme textTheme,
       required ThemeColor themeColor,
     });
 
+/// Builds a legacy [CheckboxThemeData] from semantic colors and text roles.
 typedef CheckboxThemeBuilder =
     CheckboxThemeData Function({
       required ThemeColor themeColor,
       required AppTextTheme textTheme,
     });
 
+/// Builds a legacy [MenuThemeData] from semantic colors and text roles.
 typedef MenuThemeBuilder =
     MenuThemeData Function({
       required ThemeColor themeColor,
       required AppTextTheme textTheme,
     });
 
+/// Builds a legacy [ChipThemeData] from semantic colors and text roles.
 typedef ChipThemeBuilder =
     ChipThemeData Function({
       required ThemeColor themeColor,
       required AppTextTheme textTheme,
     });
 
-/// Configuration class for creating AppTheme instances
+/// Configuration used to create an [AppTheme].
 ///
-/// This class encapsulates all the configuration options needed to create
-/// a consistent theme across the application. It provides a cleaner API
-/// by grouping related parameters and setting sensible defaults.
+/// New code should provide [designSystem], which groups colors, typography,
+/// screen chrome, decoration tokens, component behavior, FlexColorScheme
+/// overrides, platform, Material version, and font family in one reusable
+/// object.
 ///
-/// Example usage:
-/// ```dart
-/// final config = AppThemeConfig(
-///   screenTheme: myScreenTheme,
-///   themeColor: myThemeColor,
-///   fontFamily: 'Poppins',
-/// );
-/// final appTheme = AppTheme.create(config);
-/// ```
+/// The legacy fields remain supported for existing apps that already pass
+/// [screenTheme], [themeColor], an optional [appTextTheme], and component
+/// builder callbacks. When [designSystem] is omitted, [AppTheme.create]
+/// normalizes those legacy pieces into an [AppDesignSystem] internally.
 class AppThemeConfig {
-  /// Screen-specific theme configuration for different device sizes
-  final ScreenTheme screenTheme;
+  /// Preferred design-system configuration for generated themes.
+  final AppDesignSystem? designSystem;
 
-  /// Color palette and theme colors for the application
-  final ThemeColor themeColor;
+  /// Legacy screen theme used when [designSystem] is not provided.
+  final ScreenTheme? screenTheme;
 
-  /// Whether to use Material 3 design system
+  /// Legacy semantic colors used when [designSystem] is not provided.
+  final ThemeColor? themeColor;
+
+  /// Whether generated themes should use Material 3 defaults.
   final bool useMaterial3;
 
-  /// Default font family for the application
+  /// Optional font family for generated themes.
   final String? fontFamily;
 
-  /// Pre-configured text theme, if null will be created from themeColor
+  /// Optional legacy text theme override.
   final AppTextTheme? appTextTheme;
 
-  /// Custom input decoration theme builder
+  /// Legacy input decoration builder override.
   final InputDecorationThemeBuilder inputDecorationThemeBuilder;
 
-  /// Custom text button theme builder
+  /// Legacy text button theme builder override.
   final TextButtonThemeBuilder textButtonThemeBuilder;
 
-  /// Custom elevated button theme builder
+  /// Legacy elevated button theme builder override.
   final ElevatedButtonThemeBuilder elevatedButtonThemeBuilder;
 
-  /// Custom outlined button theme builder
+  /// Legacy outlined button theme builder override.
   final OutlinedButtonThemeBuilder outlinedButtonThemeBuilder;
 
-  /// Custom tab bar theme builder
+  /// Legacy tab bar theme builder override.
   final TabBarThemeBuilder tabBarThemeBuilder;
 
-  /// Custom checkbox theme builder
+  /// Legacy checkbox theme builder override.
   final CheckboxThemeBuilder checkboxThemeBuilder;
 
-  /// Custom menu theme builder
+  /// Legacy menu theme builder override.
   final MenuThemeBuilder menuThemeBuilder;
 
-  /// Custom chip theme builder
+  /// Legacy chip theme builder override.
   final ChipThemeBuilder chipThemeBuilder;
 
-  /// Target platform for platform-specific theming
+  /// Optional platform override for generated [ThemeData].
   final TargetPlatform? targetPlatform;
 
+  /// Creates theme configuration from a design system or legacy theme pieces.
+  ///
+  /// Provide either [designSystem] or both [screenTheme] and [themeColor]. If
+  /// both are supplied, [designSystem] wins and legacy builder callbacks are
+  /// ignored
+  /// for design-system-owned components.
   const AppThemeConfig({
-    required this.screenTheme,
-    required this.themeColor,
+    this.designSystem,
+    this.screenTheme,
+    this.themeColor,
     this.useMaterial3 = true,
     this.fontFamily,
     this.appTextTheme,
@@ -126,41 +150,21 @@ class AppThemeConfig {
     this.menuThemeBuilder = AppTheme.buildMenuTheme,
     this.chipThemeBuilder = AppTheme.buildChipTheme,
     this.targetPlatform,
-  });
+  }) : assert(
+         designSystem != null || (screenTheme != null && themeColor != null),
+         'Provide designSystem or both screenTheme and themeColor.',
+       );
 }
 
-/// A comprehensive theme wrapper that provides a complete Flutter ThemeData
-/// with consistent styling for all UI components.
+/// Material theme wrapper that attaches app semantic theme extensions.
 ///
-/// This class serves as the main entry point for theme creation in the
-/// application. It combines various theme components
-/// (colors, text styles, component themes) into a cohesive design system.
-///
-/// Features:
-/// - Consistent color palette across all components
-/// - Standardized text styles and typography
-/// - Material Design 3 support
-/// - Platform-specific adaptations
-/// - Customizable component themes
-/// - Extension-based theme data for custom components
-///
-/// Usage:
-/// ```dart
-/// // Using the simplified factory
-/// final theme = AppTheme.create(AppThemeConfig(
-///   screenTheme: screenTheme,
-///   themeColor: themeColor,
-/// ));
-///
-/// // Using the legacy factory for backward compatibility
-/// final theme = AppTheme.factory(
-///   screenTheme: screenTheme,
-///   themeColor: themeColor,
-///   useMaterial3: true,
-/// );
-/// ```
+/// [AppTheme.create] builds a Flutter [ThemeData] through FlexColorScheme, then
+/// applies repo-specific overrides and attaches [ScreenTheme],
+/// [ThemeColorExtension], [AppTextThemeExtension], and [AppDecorationTheme].
+/// Apps pass [theme] to `MaterialApp.theme` or `MaterialApp.darkTheme`, while
+/// [name]
+/// is useful for pickers, playgrounds, and debug tooling.
 class AppTheme {
-  // Design constants for consistent UI elements
   static const double _defaultBorderRadius = 8.0;
   static const Size _minimumButtonSize = Size(88, 40);
   static const EdgeInsets _buttonPadding = EdgeInsets.symmetric(horizontal: 16);
@@ -169,39 +173,39 @@ class AppTheme {
     vertical: 6,
   );
 
-  /// Human-readable name for the theme (e.g., "light", "dark")
+  /// Human-readable theme name.
   final String name;
 
-  /// The complete Flutter theme data
+  /// Generated Flutter Material theme data.
   final ThemeData theme;
 
+  /// Creates a named theme wrapper around generated [ThemeData].
   const AppTheme({required this.name, required this.theme});
 
-  /// Primary factory method for creating AppTheme instances
+  /// Creates an app theme from [config].
   ///
-  /// This method uses the configuration pattern to create themes with
-  /// sensible defaults while allowing full customization when needed.
-  ///
-  /// [config] - Configuration object containing all theme parameters
-  ///
-  /// Returns an [AppTheme] instance with the specified configuration
+  /// The preferred path resolves [AppThemeConfig.designSystem], creates or
+  /// reuses its [AppTextTheme], builds Material defaults with FlexColorScheme,
+  /// and then attaches the semantic extensions used by `context.themeColor`,
+  /// `context.textTheme`, `context.screenTheme`, and `context.decorationTheme`.
   factory AppTheme.create(AppThemeConfig config) {
+    final designSystem = _resolveDesignSystem(config);
     final appTextTheme =
-        config.appTextTheme ?? AppTextTheme.create(config.themeColor);
-    final brightness = config.themeColor.brightness;
+        designSystem.textTheme ??
+        designSystem.typography.create(designSystem.colors);
 
     return AppTheme(
-      name: brightness.name,
-      theme: _buildThemeData(config, appTextTheme),
+      name: designSystem.name,
+      theme: _buildThemeData(config, designSystem, appTextTheme),
     );
   }
 
-  /// Legacy factory method for backward compatibility
+  /// Creates an app theme from legacy theme pieces.
   ///
-  /// This method maintains the original API while internally using
-  /// the new configuration-based approach. Use [AppTheme.create] for new code.
-  ///
-  /// @deprecated Use [AppTheme.create] with [AppThemeConfig] instead
+  /// Prefer [AppTheme.create] with [AppThemeConfig.designSystem] for new code.
+  /// This factory remains a compatibility wrapper for older app code that
+  /// passes [ScreenTheme], [ThemeColor], and optional per-component builder
+  /// callbacks.
   factory AppTheme.factory({
     required ScreenTheme screenTheme,
     required ThemeColor themeColor,
@@ -242,93 +246,216 @@ class AppTheme {
     );
   }
 
-  /// Builds the complete ThemeData from configuration and text theme
-  ///
-  /// This method orchestrates the creation of all theme components:
-  /// - Basic theme properties (colors, fonts, platform)
-  /// - Component-specific themes (buttons, inputs, app bar, etc.)
-  /// - Theme extensions for custom components
-  ///
-  /// [config] - Theme configuration containing all settings
-  /// [appTextTheme] - Text theme to be used throughout the app
-  ///
-  /// Returns a complete [ThemeData] instance
+  static AppDesignSystem _resolveDesignSystem(AppThemeConfig config) {
+    final designSystem = config.designSystem;
+    if (designSystem != null) {
+      return designSystem;
+    }
+
+    final themeColor = config.themeColor!;
+    final appTextTheme = config.appTextTheme;
+    return AppDesignSystem(
+      name: themeColor.brightness.name,
+      colors: themeColor,
+      screenTheme: config.screenTheme!,
+      typography: AppTypographyTheme(
+        override: appTextTheme == null ? null : (_) => appTextTheme,
+      ),
+      textTheme: appTextTheme,
+      targetPlatform: config.targetPlatform,
+      useMaterial3: config.useMaterial3,
+      fontFamily: config.fontFamily,
+    );
+  }
+
   static ThemeData _buildThemeData(
     AppThemeConfig config,
+    AppDesignSystem designSystem,
     AppTextTheme appTextTheme,
   ) {
-    return ThemeData(
-      // Core theme properties
-      brightness: config.themeColor.brightness,
-      fontFamily: config.fontFamily,
+    final colors = designSystem.colors;
+    final decoration = designSystem.decoration;
+    final components = designSystem.components;
+    final baseTheme = _buildFlexThemeData(designSystem, appTextTheme);
+    final useDesignSystem = config.designSystem != null;
+
+    return baseTheme.copyWith(
+      brightness: colors.brightness,
       textTheme: appTextTheme,
-      useMaterial3: config.useMaterial3,
-      platform: config.targetPlatform,
-
-      // Color properties
-      primaryColor: config.themeColor.themePrimary,
-      primaryColorLight: config.themeColor.themePrimaryLight,
-      primaryColorDark: config.themeColor.themePrimaryDark,
-      cardColor: config.themeColor.cardBackground,
-      canvasColor: config.themeColor.canvasColor,
-      scaffoldBackgroundColor: config.themeColor.scaffoldBackgroundColor,
-      unselectedWidgetColor: config.themeColor.disableColor,
-      splashColor: config.themeColor.splashColor,
-      shadowColor: config.themeColor.shadowColor,
-      disabledColor: config.themeColor.disableColor,
-      dividerColor: config.themeColor.dividerColor,
-
-      // Component themes - using builder pattern for customization
-      inputDecorationTheme: config.inputDecorationThemeBuilder(
-        themeColor: config.themeColor,
-        appTextTheme: appTextTheme,
-      ),
-      textSelectionTheme: _buildTextSelectionTheme(config.themeColor),
+      primaryTextTheme: appTextTheme,
+      platform: designSystem.targetPlatform,
+      primaryColor: colors.themePrimary,
+      primaryColorLight: colors.themePrimaryLight,
+      primaryColorDark: colors.themePrimaryDark,
+      cardColor: colors.cardBackground,
+      canvasColor: colors.canvasColor,
+      scaffoldBackgroundColor: colors.scaffoldBackgroundColor,
+      unselectedWidgetColor: colors.disableColor,
+      splashColor: colors.splashColor,
+      shadowColor: colors.shadowColor,
+      disabledColor: colors.disableColor,
+      dividerColor: colors.dividerColor,
+      inputDecorationTheme: useDesignSystem
+          ? components.inputDecorationTheme(
+              colors: colors,
+              textTheme: appTextTheme,
+              decoration: decoration,
+            )
+          : config.inputDecorationThemeBuilder(
+              themeColor: colors,
+              appTextTheme: appTextTheme,
+            ),
+      textSelectionTheme: _buildTextSelectionTheme(colors),
       buttonTheme: _buildButtonTheme(),
       textButtonTheme: config.textButtonThemeBuilder(
         textTheme: appTextTheme,
-        themeColor: config.themeColor,
+        themeColor: colors,
       ),
       elevatedButtonTheme: config.elevatedButtonThemeBuilder(
         textTheme: appTextTheme,
-        themeColor: config.themeColor,
+        themeColor: colors,
       ),
       outlinedButtonTheme: config.outlinedButtonThemeBuilder(
         textTheme: appTextTheme,
-        themeColor: config.themeColor,
+        themeColor: colors,
       ),
-      appBarTheme: _buildAppBarTheme(config.themeColor),
+      appBarTheme: _buildAppBarTheme(colors, components),
       tabBarTheme: config.tabBarThemeBuilder(
         textTheme: appTextTheme,
-        themeColor: config.themeColor,
+        themeColor: colors,
       ),
-      checkboxTheme: config.checkboxThemeBuilder(
-        themeColor: config.themeColor,
-        textTheme: appTextTheme,
-      ),
-      chipTheme: config.chipThemeBuilder(
-        themeColor: config.themeColor,
-        textTheme: appTextTheme,
-      ),
+      checkboxTheme: useDesignSystem
+          ? components.checkboxTheme(colors: colors, decoration: decoration)
+          : config.checkboxThemeBuilder(
+              themeColor: colors,
+              textTheme: appTextTheme,
+            ),
+      chipTheme: useDesignSystem
+          ? components.chipTheme(
+              colors: colors,
+              textTheme: appTextTheme,
+              decoration: decoration,
+            )
+          : config.chipThemeBuilder(
+              themeColor: colors,
+              textTheme: appTextTheme,
+            ),
       menuTheme: config.menuThemeBuilder(
-        themeColor: config.themeColor,
+        themeColor: colors,
         textTheme: appTextTheme,
       ),
-      popupMenuTheme: _buildPopupMenuTheme(config.themeColor, appTextTheme),
-      menuButtonTheme: _buildMenuButtonTheme(config.themeColor, appTextTheme),
-      dividerTheme: _buildDividerTheme(config.themeColor),
-      colorScheme: _buildColorScheme(config.themeColor),
-
-      // Theme extensions for custom components
+      popupMenuTheme: _buildPopupMenuTheme(colors, appTextTheme, decoration),
+      menuButtonTheme: _buildMenuButtonTheme(colors, appTextTheme, decoration),
+      dividerTheme: _buildDividerTheme(colors, decoration),
+      cardTheme: components.cardTheme(colors: colors, decoration: decoration),
+      scrollbarTheme: components.scrollbarTheme(
+        colors: colors,
+        decoration: decoration,
+      ),
+      dialogTheme: components.dialogTheme(
+        colors: colors,
+        textTheme: appTextTheme,
+        decoration: decoration,
+      ),
+      bottomSheetTheme: components.bottomSheetTheme(
+        colors: colors,
+        decoration: decoration,
+      ),
+      snackBarTheme: components.snackBarTheme(
+        colors: colors,
+        textTheme: appTextTheme,
+        decoration: decoration,
+      ),
+      listTileTheme: components.listTileTheme(
+        colors: colors,
+        textTheme: appTextTheme,
+        decoration: decoration,
+      ),
+      iconTheme: components.iconTheme(colors: colors),
+      primaryIconTheme: components.iconTheme(colors: colors),
+      floatingActionButtonTheme: components.floatingActionButtonTheme(
+        colors: colors,
+        textTheme: appTextTheme,
+        decoration: decoration,
+      ),
+      navigationBarTheme: components.navigationBarTheme(
+        colors: colors,
+        textTheme: appTextTheme,
+        decoration: decoration,
+      ),
+      drawerTheme: components.drawerTheme(
+        colors: colors,
+        decoration: decoration,
+      ),
+      tooltipTheme: components.tooltipTheme(
+        colors: colors,
+        textTheme: appTextTheme,
+        decoration: decoration,
+      ),
+      progressIndicatorTheme: components.progressIndicatorTheme(
+        colors: colors,
+        decoration: decoration,
+      ),
+      switchTheme: components.switchTheme(colors: colors),
+      radioTheme: components.radioTheme(colors: colors),
+      colorScheme: _buildColorScheme(colors),
       extensions: [
-        config.screenTheme,
-        ThemeColorExtension(colors: config.themeColor),
+        designSystem.screenTheme,
+        ThemeColorExtension(colors: colors),
         AppTextThemeExtension(textTheme: appTextTheme),
+        decoration,
       ],
     );
   }
 
-  /// Creates text selection theme for consistent cursor and selection colors
+  static ThemeData _buildFlexThemeData(
+    AppDesignSystem designSystem,
+    AppTextTheme textTheme,
+  ) {
+    final colors = designSystem.colors;
+    final schemeColor = FlexSchemeColor(
+      primary: colors.primary,
+      primaryContainer: colors.primaryVariant,
+      secondary: colors.secondary,
+      secondaryContainer: colors.secondaryVariant,
+      tertiary: colors.schemeAction,
+      appBarColor: colors.appbarBackgroundColor,
+      error: colors.error,
+    );
+    final subThemesData =
+        designSystem.flexSubThemesData ??
+        designSystem.components.flexSubThemesData(
+          decoration: designSystem.decoration,
+          textTheme: textTheme,
+        );
+
+    if (colors.brightness == Brightness.dark) {
+      return FlexColorScheme.dark(
+        colors: designSystem.flexSchemeData?.dark ?? schemeColor,
+        subThemesData: subThemesData,
+        useMaterial3: designSystem.useMaterial3,
+        fontFamily: designSystem.fontFamily,
+        textTheme: textTheme,
+        primaryTextTheme: textTheme,
+        platform: designSystem.targetPlatform,
+        scaffoldBackground: colors.scaffoldBackgroundColor,
+        appBarBackground: colors.appbarBackgroundColor,
+      ).toTheme;
+    }
+
+    return FlexColorScheme.light(
+      colors: designSystem.flexSchemeData?.light ?? schemeColor,
+      subThemesData: subThemesData,
+      useMaterial3: designSystem.useMaterial3,
+      fontFamily: designSystem.fontFamily,
+      textTheme: textTheme,
+      primaryTextTheme: textTheme,
+      platform: designSystem.targetPlatform,
+      scaffoldBackground: colors.scaffoldBackgroundColor,
+      appBarBackground: colors.appbarBackgroundColor,
+    ).toTheme;
+  }
+
   static TextSelectionThemeData _buildTextSelectionTheme(
     ThemeColor themeColor,
   ) {
@@ -339,30 +466,32 @@ class AppTheme {
     );
   }
 
-  /// Creates basic button theme with standard height
   static ButtonThemeData _buildButtonTheme() {
     return const ButtonThemeData(height: 38);
   }
 
-  /// Creates app bar theme with background and foreground colors
-  static AppBarTheme _buildAppBarTheme(ThemeColor themeColor) {
+  static AppBarTheme _buildAppBarTheme(
+    ThemeColor themeColor,
+    AppComponentTheme components,
+  ) {
     return AppBarTheme(
       backgroundColor: themeColor.appbarBackgroundColor ?? themeColor.primary,
       foregroundColor: themeColor.appbarForegroundColor,
-      centerTitle: true,
+      centerTitle: components.appBarCenterTitle,
     );
   }
 
-  /// Creates divider theme with consistent styling
-  static DividerThemeData _buildDividerTheme(ThemeColor themeColor) {
+  static DividerThemeData _buildDividerTheme(
+    ThemeColor themeColor,
+    AppDecorationTheme decoration,
+  ) {
     return DividerThemeData(
       color: themeColor.dividerColor,
-      thickness: 1,
-      space: 1,
+      thickness: decoration.borderThin,
+      space: decoration.borderThin,
     );
   }
 
-  /// Creates Material 3 color scheme from theme colors
   static ColorScheme _buildColorScheme(ThemeColor themeColor) {
     return ColorScheme(
       primary: themeColor.primary,
@@ -379,17 +508,10 @@ class AppTheme {
     );
   }
 
-  /// Standard border radius for consistent UI elements
   static BorderRadius get _borderRadius =>
       BorderRadius.circular(_defaultBorderRadius);
 
-  /// Creates text button theme with proper state management
-  ///
-  /// Configures text buttons with:
-  /// - Consistent text styling
-  /// - State-based color resolution
-  /// - Standard sizing and padding
-  /// - Rounded corners
+  /// Builds the default legacy text button theme.
   static TextButtonThemeData buildTextButtonTheme({
     required AppTextTheme textTheme,
     required ThemeColor themeColor,
@@ -412,13 +534,7 @@ class AppTheme {
     );
   }
 
-  /// Creates elevated button theme with background and foreground colors
-  ///
-  /// Configures elevated buttons with:
-  /// - Disabled state handling
-  /// - Consistent elevation and shadows
-  /// - State-based color resolution
-  /// - Standard sizing and padding
+  /// Builds the default legacy elevated button theme.
   static ElevatedButtonThemeData buildElevatedButtonTheme({
     required ThemeColor themeColor,
     required AppTextTheme textTheme,
@@ -448,12 +564,7 @@ class AppTheme {
     );
   }
 
-  /// Creates outlined button theme with borders and state management
-  ///
-  /// Configures outlined buttons with:
-  /// - State-dependent border colors
-  /// - Background color handling
-  /// - Consistent styling with other buttons
+  /// Builds the default legacy outlined button theme.
   static OutlinedButtonThemeData buildOutlinedButtonTheme({
     required ThemeColor themeColor,
     required AppTextTheme textTheme,
@@ -486,13 +597,7 @@ class AppTheme {
     );
   }
 
-  /// Creates input decoration theme for form fields
-  ///
-  /// Configures text fields with:
-  /// - Consistent border styles for all states
-  /// - Proper label behavior
-  /// - Error state styling
-  /// - Standard padding
+  /// Builds the default legacy input decoration theme.
   static InputDecorationTheme buildInputDecorationTheme({
     required ThemeColor themeColor,
     required AppTextTheme appTextTheme,
@@ -500,8 +605,7 @@ class AppTheme {
   }) {
     final bdRadius = borderRadius ?? _borderRadius;
 
-    /// Helper method to create consistent input field borders
-    OutlineInputBorder _createInputBorder(
+    OutlineInputBorder createInputBorder(
       Color color,
       BorderRadius borderRadius,
     ) {
@@ -512,11 +616,11 @@ class AppTheme {
     }
 
     return InputDecorationTheme(
-      border: _createInputBorder(themeColor.borderColor, bdRadius),
-      enabledBorder: _createInputBorder(themeColor.borderColor, bdRadius),
-      focusedBorder: _createInputBorder(themeColor.primary, bdRadius),
-      disabledBorder: _createInputBorder(themeColor.disableColor, bdRadius),
-      errorBorder: _createInputBorder(
+      border: createInputBorder(themeColor.borderColor, bdRadius),
+      enabledBorder: createInputBorder(themeColor.borderColor, bdRadius),
+      focusedBorder: createInputBorder(themeColor.primary, bdRadius),
+      disabledBorder: createInputBorder(themeColor.disableColor, bdRadius),
+      errorBorder: createInputBorder(
         appTextTheme.inputError?.color ?? Colors.red,
         bdRadius,
       ),
@@ -527,7 +631,7 @@ class AppTheme {
     );
   }
 
-  /// Creates tab bar theme with label styling and indicator colors
+  /// Builds the default legacy tab bar theme.
   static TabBarThemeData buildTabBarTheme({
     required AppTextTheme textTheme,
     required ThemeColor themeColor,
@@ -543,113 +647,30 @@ class AppTheme {
     );
   }
 
-  /// Creates checkbox theme with state-based styling
-  ///
-  /// Configures checkboxes with:
-  /// - State-dependent fill colors
-  /// - Consistent check marks and borders
-  /// - Hover and focus state styling
-  /// - Material state overlays
+  /// Builds the default legacy checkbox theme.
   static CheckboxThemeData buildCheckboxTheme({
     required ThemeColor themeColor,
     required AppTextTheme textTheme,
   }) {
-    return CheckboxThemeData(
-      checkColor: WidgetStateProperty.resolveWith<Color?>((states) {
-        // Color of the check mark inside the checkbox
-        if (states.contains(WidgetState.disabled)) {
-          return themeColor.checkboxCheckColor.withValues(alpha: 0.5);
-        }
-        return themeColor.checkboxCheckColor;
-      }),
-      fillColor: WidgetStateProperty.resolveWith<Color?>((states) {
-        // Background color of the checkbox
-        if (states.contains(WidgetState.disabled)) {
-          return themeColor.checkboxDisabledColor;
-        }
-        if (states.contains(WidgetState.selected)) {
-          return themeColor.checkboxActiveColor;
-        }
-        return Colors.transparent;
-      }),
-      overlayColor: WidgetStateProperty.resolveWith<Color?>((states) {
-        // Hover/ripple effect color
-        if (states.contains(WidgetState.pressed)) {
-          return themeColor.checkboxActiveColor.withValues(alpha: 0.1);
-        }
-        if (states.contains(WidgetState.hovered)) {
-          return themeColor.checkboxActiveColor.withValues(alpha: 0.08);
-        }
-        if (states.contains(WidgetState.focused)) {
-          return themeColor.checkboxActiveColor.withValues(alpha: 0.12);
-        }
-        return null;
-      }),
-      side: WidgetStateBorderSide.resolveWith((states) {
-        // Border styling for unchecked state
-        if (states.contains(WidgetState.disabled)) {
-          return BorderSide(color: themeColor.checkboxDisabledColor, width: 1);
-        }
-        if (states.contains(WidgetState.selected)) {
-          return BorderSide(color: themeColor.checkboxActiveColor, width: 1);
-        }
-        return BorderSide(color: themeColor.checkboxBorderColor, width: 1);
-      }),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
-      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      visualDensity: VisualDensity.compact,
+    return const AppComponentTheme().checkboxTheme(
+      colors: themeColor,
+      decoration: const AppDecorationTheme(),
     );
   }
 
-  /// Creates chip theme for Chip widgets
-  ///
-  /// Configures chips with:
-  /// - Consistent background and border colors
-  /// - State-based styling for selection and disabled states
-  /// - Proper text styling for chip labels
-  /// - Material elevation and rounded borders
-  /// - Hover and press state effects
+  /// Builds the default legacy chip theme.
   static ChipThemeData buildChipTheme({
     required ThemeColor themeColor,
     required AppTextTheme textTheme,
   }) {
-    return ChipThemeData(
-      backgroundColor: themeColor.chipBackgroundColor,
-      disabledColor: themeColor.chipDisabledColor,
-      selectedColor: themeColor.chipSelectedColor,
-      secondarySelectedColor: themeColor.chipSelectedColor.withValues(
-        alpha: 0.12,
-      ),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      labelStyle: textTheme.bodyMedium?.copyWith(
-        color: themeColor.chipLabelColor,
-      ),
-      secondaryLabelStyle: textTheme.bodySmall?.copyWith(
-        color: themeColor.chipLabelColor,
-      ),
-      brightness: themeColor.brightness,
-      elevation: 0,
-      pressElevation: 1,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-        side: BorderSide(color: themeColor.chipBorderColor, width: 1),
-      ),
-      selectedShadowColor: Colors.transparent,
-      showCheckmark: true,
-      checkmarkColor: themeColor.checkboxCheckColor,
-      deleteIconColor: themeColor.deleteIconColor,
-      iconTheme: IconThemeData(color: themeColor.chipLabelColor, size: 18),
+    return const AppComponentTheme().chipTheme(
+      colors: themeColor,
+      textTheme: textTheme,
+      decoration: const AppDecorationTheme(),
     );
   }
 
-  /// Creates menu theme for context menus, dropdowns, and popup menus
-  ///
-  /// Configures menus based on the design with:
-  /// - Consistent background colors and shadows
-  /// - Proper text styling for menu items
-  /// - State-based styling for selection and hover
-  /// - Material elevation and border radius
-  /// - Comprehensive styling for MenuAnchor, DropdownMenu, and PopupMenuButton
+  /// Builds the default legacy menu theme.
   static MenuThemeData buildMenuTheme({
     required ThemeColor themeColor,
     required AppTextTheme textTheme,
@@ -680,21 +701,18 @@ class AppTheme {
     );
   }
 
-  /// Creates popup menu theme for PopupMenuButton widgets
-  ///
-  /// Configures popup menus with consistent styling that complements
-  /// the main menu theme, specifically for traditional popup menu buttons.
   static PopupMenuThemeData _buildPopupMenuTheme(
     ThemeColor themeColor,
     AppTextTheme textTheme,
+    AppDecorationTheme decoration,
   ) {
     return PopupMenuThemeData(
       color: themeColor.cardBackground,
-      elevation: 8.0,
+      elevation: decoration.elevationMd,
       shadowColor: themeColor.shadowColor.withValues(alpha: 0.16),
       surfaceTintColor: Colors.transparent,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(_defaultBorderRadius),
+        borderRadius: decoration.radiusMdBorder,
         side: BorderSide(
           color: themeColor.borderColor.withValues(alpha: 0.12),
           width: 0.5,
@@ -705,13 +723,10 @@ class AppTheme {
     );
   }
 
-  /// Creates menu button theme for MenuAnchor and related button widgets
-  ///
-  /// Provides consistent styling for buttons that trigger menus,
-  /// ensuring visual harmony between menu triggers and menu content.
   static MenuButtonThemeData _buildMenuButtonTheme(
     ThemeColor themeColor,
     AppTextTheme textTheme,
+    AppDecorationTheme decoration,
   ) {
     return MenuButtonThemeData(
       style: ButtonStyle(
@@ -745,23 +760,23 @@ class AppTheme {
           return Colors.transparent;
         }),
         padding: WidgetStateProperty.all(
-          const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          EdgeInsets.symmetric(
+            horizontal: decoration.spaceMd,
+            vertical: decoration.spaceSm,
+          ),
         ),
-        minimumSize: WidgetStateProperty.all(const Size(0, 36)),
+        minimumSize: WidgetStateProperty.all(Size(0, decoration.spaceXxl + 4)),
         shape: WidgetStateProperty.all(
-          RoundedRectangleBorder(borderRadius: BorderRadius.circular(6)),
+          RoundedRectangleBorder(borderRadius: decoration.radiusSmBorder),
         ),
-        elevation: WidgetStateProperty.all(0),
+        elevation: WidgetStateProperty.all(decoration.elevationNone),
         visualDensity: VisualDensity.compact,
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
       ),
     );
   }
 
-  /// Creates a copy of this theme with optional modifications
-  ///
-  /// Useful for creating theme variations or overriding specific properties
-  /// while maintaining the rest of the theme configuration.
+  /// Creates a copy with selected theme wrapper values replaced.
   AppTheme copyWith({String? name, ThemeData? theme}) {
     return AppTheme(name: name ?? this.name, theme: theme ?? this.theme);
   }

--- a/plugins/fl_theme/lib/src/utils/extension.dart
+++ b/plugins/fl_theme/lib/src/utils/extension.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
 
+/// HSL-based color adjustments used by theme token defaults.
 extension FlThemeColorExt on Color {
+  /// Returns this color with its HSL lightness reduced by [amount].
+  ///
+  /// [amount] must be between `0` and `1`. Hue, saturation, and alpha are
+  /// preserved by the HSL conversion.
   Color darken([double amount = .1]) {
     assert(amount >= 0 && amount <= 1, 'amount >= 0 && amount <= 1');
 
@@ -10,6 +15,10 @@ extension FlThemeColorExt on Color {
     return hslDark.toColor();
   }
 
+  /// Returns this color with its HSL lightness increased by [amount].
+  ///
+  /// [amount] must be between `0` and `1`. Hue, saturation, and alpha are
+  /// preserved by the HSL conversion.
   Color lighten([double amount = .1]) {
     assert(amount >= 0 && amount <= 1, 'amount >= 0 && amount <= 1');
 

--- a/plugins/fl_theme/pubspec.lock
+++ b/plugins/fl_theme/pubspec.lock
@@ -120,6 +120,22 @@ packages:
       relative: true
     source: path
     version: "1.0.0"
+  flex_color_scheme:
+    dependency: "direct main"
+    description:
+      name: flex_color_scheme
+      sha256: ab854146f201d2d62cc251fd525ef023b84182c4a0bfe4ae4c18ffc505b412d3
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.4.0"
+  flex_seed_scheme:
+    dependency: transitive
+    description:
+      name: flex_seed_scheme
+      sha256: a3183753bbcfc3af106224bff3ab3e1844b73f58062136b7499919f49f3667e7
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -361,4 +377,4 @@ packages:
     version: "15.0.0"
 sdks:
   dart: ">=3.9.0-0 <4.0.0"
-  flutter: ">=3.32.0"
+  flutter: ">=3.38.0"

--- a/plugins/fl_theme/pubspec.yaml
+++ b/plugins/fl_theme/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   fl_utils:
     path: ../fl_utils
 
+  flex_color_scheme: ^8.4.0
   pedantic: ^1.11.1
 
 dev_dependencies:

--- a/plugins/fl_theme/test/fl_theme_test.dart
+++ b/plugins/fl_theme/test/fl_theme_test.dart
@@ -1,5 +1,167 @@
+import 'package:fl_theme/fl_theme.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('fl_theme test', () async {});
+  test('parses and exports JSON theme config', () {
+    final config = ThemeJsonConfig.decode('''
+{
+  "schemaVersion": 1,
+  "name": "Ocean Blue",
+  "mode": "light",
+  "useMaterial3": true,
+  "colors": {
+    "primary": "#3B82F6",
+    "secondary": "#EFF6FF",
+    "surface": "#FFFFFF",
+    "background": "#F3F4F6",
+    "error": "#B00020",
+    "appBarBackground": "#FFFFFF",
+    "appBarForeground": "#111827"
+  },
+  "typography": {
+    "buttonFontSize": 15,
+    "buttonFontWeight": 600,
+    "bodyFontSize": 14
+  },
+  "decoration": {
+    "radius": 8,
+    "buttonRadius": 8,
+    "inputRadius": 8,
+    "chipRadius": 16,
+    "screenPadding": 16
+  },
+  "components": {
+    "inputFilled": false,
+    "appBarCenterTitle": true,
+    "chipShowCheckmark": true
+  },
+  "screen": {
+    "showHeaderImage": false,
+    "hasBottomBorderRadius": false,
+    "showAppbarDivider": false,
+    "centerTitle": false
+  }
+}
+''');
+
+    expect(config.name, 'Ocean Blue');
+    expect(config.colors.primary, const Color(0xFF3B82F6));
+    expect(config.toJson()['colors']['primary'], '#FF3B82F6');
+  });
+
+  test('invalid JSON color reports field path', () {
+    expect(
+      () => ThemeJsonConfig.decode('''
+{
+  "colors": {"primary": "blue"}
+}
+'''),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          contains('colors.primary'),
+        ),
+      ),
+    );
+  });
+
+  testWidgets('design system theme exposes extensions', (tester) async {
+    final designSystem = AppDesignSystem.fromJsonConfig(
+      const ThemeJsonConfig(
+        name: 'Test Theme',
+        decoration: ThemeJsonDecoration(screenPadding: 20),
+        typography: ThemeJsonTypography(buttonFontSize: 18),
+      ),
+    );
+    final appTheme = AppTheme.create(
+      AppThemeConfig(designSystem: designSystem),
+    );
+
+    late BuildContext capturedContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: appTheme.theme,
+        home: Builder(
+          builder: (context) {
+            capturedContext = context;
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+
+    expect(capturedContext.themeColor.primary, const Color(0xFF3B82F6));
+    expect(capturedContext.textTheme.buttonText?.fontSize, 18);
+    expect(capturedContext.decorationTheme.screenPadding, 20);
+    expect(capturedContext.screenTheme, isA<ScreenTheme>());
+  });
+
+  test('design system configures broad Material component themes', () {
+    final designSystem = AppDesignSystem.fromJsonConfig(
+      const ThemeJsonConfig(
+        colors: ThemeJsonColor(
+          primary: Color(0xFF16A34A),
+          secondary: Color(0xFFDCFCE7),
+          surface: Color(0xFFFFFFFF),
+          background: Color(0xFFF0FDF4),
+          error: Color(0xFFDC2626),
+        ),
+        decoration: ThemeJsonDecoration(
+          radius: 10,
+          buttonRadius: 18,
+          inputRadius: 12,
+          chipRadius: 24,
+          screenPadding: 18,
+        ),
+        components: ThemeJsonComponent(inputFilled: true),
+      ),
+    );
+    final theme = AppTheme.create(
+      AppThemeConfig(designSystem: designSystem),
+    ).theme;
+
+    expect(theme.cardTheme.color, const Color(0xFFFFFFFF));
+    expect(theme.scrollbarTheme.interactive, isTrue);
+    expect(theme.dialogTheme.backgroundColor, const Color(0xFFFFFFFF));
+    expect(theme.bottomSheetTheme.showDragHandle, isTrue);
+    expect(theme.snackBarTheme.behavior, SnackBarBehavior.floating);
+    expect(theme.listTileTheme.selectedColor, const Color(0xFF16A34A));
+    expect(
+      theme.iconTheme.color,
+      theme.extension<ThemeColorExtension>()!.colors.labelText,
+    );
+    expect(
+      theme.floatingActionButtonTheme.backgroundColor,
+      const Color(0xFF16A34A),
+    );
+    expect(theme.navigationBarTheme.backgroundColor, const Color(0xFFFFFFFF));
+    expect(theme.drawerTheme.backgroundColor, const Color(0xFFFFFFFF));
+    expect(theme.tooltipTheme.preferBelow, isFalse);
+    expect(theme.progressIndicatorTheme.color, const Color(0xFF16A34A));
+    expect(
+      theme.switchTheme.trackColor?.resolve({WidgetState.selected}),
+      const Color(0xFF16A34A),
+    );
+    expect(
+      theme.radioTheme.fillColor?.resolve({WidgetState.selected}),
+      const Color(0xFF16A34A),
+    );
+  });
+
+  test('legacy factory remains compatible', () {
+    final appTheme = AppTheme.factory(
+      screenTheme: const ScreenTheme(),
+      themeColor: ThemeColor(
+        primary: Colors.blue,
+        secondary: Colors.orange,
+        brightness: Brightness.light,
+      ),
+    );
+
+    expect(appTheme.theme.extension<ThemeColorExtension>(), isNotNull);
+    expect(appTheme.theme.extension<AppTextThemeExtension>(), isNotNull);
+    expect(appTheme.theme.extension<AppDecorationTheme>(), isNotNull);
+  });
 }


### PR DESCRIPTION
## Summary
- Add JSON-backed `AppDesignSystem` theme generation with FlexColorScheme integration and broader Material component theme coverage.
- Add the `fl_theme` web playground with schema controls, JSON import/export, presets, responsive preview, and optional device-frame mode.
- Update theme docs/guidance and app usage to demonstrate screen theme configuration through the app adapter.

## Test plan
- [x] `flutter analyze` in `plugins/fl_theme`
- [x] `fvm flutter test` in `plugins/fl_theme`
- [x] `flutter analyze` in `plugins/fl_theme/example`
- [x] `fvm flutter test` in `plugins/fl_theme/example`
- [x] `fvm flutter build web` in `plugins/fl_theme/example`
- [x] Browser smoke tested the web playground with Playwright MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)