### PR TITLE
docs: apply generalized agent guidance

### DIFF
--- a/.agents/skills/bloc-pattern/SKILL.md
+++ b/.agents/skills/bloc-pattern/SKILL.md
@@ -127,7 +127,7 @@ class GetFeatureEvent extends FeatureEvent {
 class LoadMoreEvent extends FeatureEvent {}
 ```
 
-For events that need to surface a result back to the caller (e.g. login flows), pass a `Completer<T>` on the event and complete it inside the handler.
+For events that need to surface a result back to the caller (e.g. login flows), pass a `Completer<T>` on the event and complete it inside the handler. Choose `T` to carry the useful result object when the caller needs refreshed state; avoid returning only `bool` and forcing an immediate duplicate query.
 
 ## Loading + error handling
 

--- a/.agents/skills/data-layer/SKILL.md
+++ b/.agents/skills/data-layer/SKILL.md
@@ -135,6 +135,12 @@ class UserHive extends HiveObject {
 
 Don't reuse a `typeId` — pick a unique one across the app.
 
+## Local storage APIs
+
+Expose storage behavior through the existing DAO → repository → usecase boundaries rather than letting presentation code reach into storage directly. Prefer stable table/row operations over replacing storage infrastructure. New public DAO/repository/usecase methods should have concise Dartdoc.
+
+When a mutation produces data the caller needs, return the updated domain result instead of returning only a success flag and forcing an immediate duplicate query.
+
 ## Repository
 
 Repositories accept the API client (and optionally a local data source) by constructor and decide cache/refresh policy. They are the only layer feature blocs depend on.

--- a/.agents/skills/flutter-reviewer/SKILL.md
+++ b/.agents/skills/flutter-reviewer/SKILL.md
@@ -33,8 +33,9 @@ metadata:
 - [ ] `bloc` getter overridden to `BlocProvider.of(context)`.
 - [ ] `static String routeName` declared, leading slash, lowercase.
 - [ ] Wraps in `ScreenForm` / `MainPageForm` rather than raw `Scaffold + AppBar` unless there's a reason.
-- [ ] Translates via `trans = translate(context)` or `context.l10n`; no hardcoded user-facing strings.
+- [ ] Translates via `trans = translate(context)` or `context.l10n`; no hardcoded user-facing strings or cached localization state.
 - [ ] Action file (`<feature>.action.dart`) is a `part of` the screen and holds `_blocListener`, `onRefresh`, etc.
+- [ ] Row/list trailing content aligns consistently and supports widgets when the design needs controls or rich values.
 
 ### Routing
 
@@ -51,6 +52,7 @@ metadata:
 - [ ] No raw `Colors.white`/`Colors.black` for surfaces or text — use `context.themeColor.*`.
 - [ ] Typography uses Material 3 slot names (`titleMedium`, `bodySmall`, …) plus the `AppTextTheme` extras (`titleTiny`, `inputTitle`, `buttonText`, …) — not invented tokens like `titleMd`/`bodyXs`.
 - [ ] Buttons reuse `ThemeButton.*` defaults; per-call `style:` overrides are scoped, not redundant.
+- [ ] Existing project controls are reused before custom UI is introduced.
 
 ### Performance
 
@@ -80,6 +82,8 @@ Reply with:
 - A new state class added to `<feature>_state.dart` without a matching `_factories` entry (runtime crash on first `copyWith<T>()`).
 - A screen whose `_blocListener` doesn't call `hideLoading()` on every state — the loading indicator can stick.
 - A coordinator method built with literal route paths instead of `<Screen>.routeName`.
+- A named project architecture bypassed with an ad-hoc UI structure.
+- A custom control recreated when an existing project widget already fits.
 - A `Text(...)` with a literal English string anywhere in production code.
 - `setState` inside a `BlocBuilder.builder` (rebuild loop).
 

--- a/.agents/skills/localization/SKILL.md
+++ b/.agents/skills/localization/SKILL.md
@@ -83,6 +83,7 @@ Rules:
 
 - Key names are lowerCamelCase and describe meaning (`loginRequired`, not `auth_msg_2`).
 - Keep keys flat across the package. If two screens need different copy, use distinct keys.
+- Remove source CSV keys when the UI/API surface that used them is removed; do not leave stale generated accessors.
 - Quote values containing commas or newlines.
 - Parameters are **positional** (`{0}`, `{1}`, …); do not use named placeholders.
 - Fill every locale column. The custom CSV → ARB step writes cells as-is, so empty cells produce empty translations rather than a reliable fallback.
@@ -186,6 +187,7 @@ If shared/core strings changed, analyze `core`; if media strings changed, analyz
 - [ ] Values provided for `en` and `vi`.
 - [ ] No translation entered directly into generated `*.arb` or `*_localizations_*.dart` files.
 - [ ] `make lang` run and generated files updated.
+- [ ] Removed/renamed keys have no stale references in CSV, ARB, generated Dart, or call sites.
 - [ ] Use site reads strings via generated localization APIs, not hardcoded user-facing text.
 - [ ] Parameters use positional `{0}`, `{1}` placeholders.
 - [ ] Stale locale files/imports removed when replacing a locale.
@@ -195,6 +197,7 @@ If shared/core strings changed, analyze `core`; if media strings changed, analyz
 - Editing `intl_en.arb` or `intl_vi.arb` directly — the next `make lang` overwrites it.
 - Adding only app CSV strings when the UI actually uses `core` or `fl_media` localization.
 - Leaving old locale artifacts (`intl_th.arb`, `*_th.dart`) after replacing a locale.
+- Leaving unused keys in `localizations.csv` because only the widget code was removed.
 - Using `{name}` placeholders — use positional `{0}`.
 - Leaving empty CSV cells and assuming generated localizations will fall back to English.
 - Sneaking in raw `Text('Save')` for user-facing text.

--- a/.agents/skills/module-scaffold/SKILL.md
+++ b/.agents/skills/module-scaffold/SKILL.md
@@ -66,6 +66,25 @@ apps/main/lib/data/data_source/<feature>_repository.dart  (and *_impl.dart)
 
 For shared widgets/services, add to `core/` instead of `apps/main/`.
 
+## Compound features
+
+When a feature has more than one screen, do not flatten it into one oversized module or bypass the established presentation structure. Use a parent module that owns the parent barrel, coordinator, and route aggregator; each non-trivial child screen gets its own sub-module with `bloc/` and `views/`.
+
+```text
+<feature>/
+├── <feature>.dart
+├── <feature>_route.dart          # aggregates child routes
+├── <feature>_coordinator.dart
+├── <child_a>/
+│   ├── bloc/
+│   └── views/
+└── <child_b>/
+    ├── bloc/
+    └── views/
+```
+
+If the user says a flow should follow a named project architecture, apply that architecture directly and ask before choosing a lighter UI structure.
+
 ## Manual scaffold (when the generator does not fit)
 
 Stick to the names below — `_factories`, `Args`, `routeName`, the part wiring — because other parts of the codebase rely on them.
@@ -81,6 +100,7 @@ Stick to the names below — `_factories`, `Args`, `routeName`, the part wiring 
 
 - [ ] Tried `make run_module_generator` first.
 - [ ] Module placed under `lib/presentation/modules/<feature>/`.
+- [ ] Multi-screen feature uses a parent route/coordinator/barrel plus child sub-modules.
 - [ ] Screen extends `StateBase<T>` and has a `static String routeName`.
 - [ ] Bloc extends `AppBlocBase<E, S>` and is `@Injectable()`.
 - [ ] Route extends `IRoute` and wraps the screen in `BlocProvider`.

--- a/.agents/skills/route-config/SKILL.md
+++ b/.agents/skills/route-config/SKILL.md
@@ -148,6 +148,7 @@ Callers: `context.goToFeature(object: item)` or `context.goToFeatureById(id: '42
 - [ ] Builder wraps the screen in `BlocProvider` and creates the bloc via `injector.get(...)`.
 - [ ] `extraFromUrlQueries` provided when the screen should be deep-linkable.
 - [ ] Coordinator extension exposes typed `goToX` methods, all taking `PushBehavior`.
+- [ ] Route/coordinator methods have concise Dartdoc when they are newly introduced public APIs.
 - [ ] New `IRoute` registered in the parent / app-level `IRoute`.
 - [ ] No direct `package:go_router/go_router.dart` imports in feature code.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,18 @@ These generic agent rules come before implementation details. For the full check
 3. **Surgical changes**: every changed line should trace to the request or required generated output. Do not refactor adjacent code, reformat unrelated files, or delete unrelated dead code unless asked.
 4. **Goal-driven execution**: for multi-step work, define success criteria before coding, then verify with concrete checks such as `rg`, generation commands, analyzer, tests, or UI smoke tests.
 
+## Generalized implementation guidance
+
+- When the user names an existing architecture or pattern, follow that structure directly; ask before substituting a lighter-weight shortcut.
+- For multi-screen features, keep parent modules responsible for route/coordinator aggregation and give non-trivial child screens their own module state.
+- Reuse existing project widgets, helpers, and abstractions before creating new ones.
+- Design reusable row/list components so trailing content aligns consistently and can accept widgets when needed.
+- Add concise Dartdoc to newly introduced public APIs in reusable or cross-layer surfaces.
+- When a child flow mutates data that a caller needs, return the updated result instead of forcing an immediate duplicate read.
+- Keep storage operations behind the existing data/domain boundaries and prefer stable table/row operations over replacing storage infrastructure.
+- Remove stale source-of-truth entries and regenerated outputs when a feature surface is removed.
+- For user-facing UI changes, run an available smoke test before reporting completion, or state why it could not be run.
+
 ## Command Priority
 
 Prefer project-standard commands over ad-hoc direct commands.


### PR DESCRIPTION
## Summary
- Capture reusable implementation guardrails across the `.agents/skills/*` bundle and `AGENTS.md`.
- Covers: module structure, storage boundaries, localization cleanup, and UI review checks.

## Test plan
- [ ] Skim `AGENTS.md` and each updated `SKILL.md` for clarity and accuracy.
- [ ] Confirm no agent workflows reference removed/renamed sections.