### PR TITLE
docs(agents): refresh guidance for v2.0 architecture

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -8,12 +8,12 @@ One-line index of every skill under [`./skills/`](./skills/).
 |---|---|---|
 | [`behavioral-guardrails`](./skills/behavioral-guardrails/SKILL.md) | Clarify, simplify, make surgical changes, verify | Planning, implementing, reviewing, or refactoring |
 | [`module-scaffold`](./skills/module-scaffold/SKILL.md) | Scaffold a feature module | Starting a new screen / feature |
-| [`bloc-pattern`](./skills/bloc-pattern/SKILL.md) | `AppBlocBase` + `_StateData` + `_factories` | Adding or modifying state management |
+| [`bloc-pattern`](./skills/bloc-pattern/SKILL.md) | `CoreBlocBase` + `_StateData` + `_factories` | Adding or modifying state management |
 | [`bus-event`](./skills/bus-event/SKILL.md) | Cross-feature event synchronization | Publishing or listening to `BusEvent` updates |
 | [`extension-action`](./skills/extension-action/SKILL.md) | `*.action.dart` for screen handlers | Splitting handlers out of a bloated screen |
-| [`route-config`](./skills/route-config/SKILL.md) | `IRoute` + `CustomRouter` + coordinator | Wiring navigation |
+| [`route-config`](./skills/route-config/SKILL.md) | `IRoute` + `CustomRouter` + optional coordinator | Wiring navigation |
 | [`theme-usage`](./skills/theme-usage/SKILL.md) | `context.themeColor` + `context.textTheme` | Styling a widget |
-| [`data-layer`](./skills/data-layer/SKILL.md) | Freezed DTO + Retrofit + repo | Talking to an API or local store |
+| [`data-layer`](./skills/data-layer/SKILL.md) | Freezed DTO + Retrofit + storage seam + repo (Hive optional) | Talking to an API or local store |
 | [`error-handling`](./skills/error-handling/SKILL.md) | `CoreBlocBase.onError` + `ErrorType` router | Deciding what to do with a thrown error |
 | [`localization`](./skills/localization/SKILL.md) | CSV → ARB → `AppLocalizations` | Adding translations |
 | [`code-generation`](./skills/code-generation/SKILL.md) | `make gen_all` and friends | After editing freezed/retrofit/injectable |

--- a/.agents/ONBOARDING.md
+++ b/.agents/ONBOARDING.md
@@ -99,8 +99,8 @@ You can also call a skill explicitly:
 ## Conventions in one screen
 
 - Clean architecture: `presentation/` → `domain/` → `data/`.
-- Bloc: extends `AppBlocBase<E, S>`; abstract state hierarchy with a
-  freezed `_StateData` and a `_factories` map.
+- Bloc: extends `CoreBlocBase<E, S>` (from `package:core/core.dart`);
+  abstract state hierarchy with a freezed `_StateData` and a `_factories` map.
 - Bus events: use `BusEvent` + `EventBusManager` for cross-feature synchronization,
   not local UI callbacks or single-BLoC state.
 - Screens: `StateBase<T>`, wrapped in `ScreenForm` / `MainPageForm`,
@@ -111,8 +111,12 @@ You can also call a skill explicitly:
   slots plus the `AppTextTheme` extras (`titleTiny`, `inputTitle`, …).
 - Localization: edit `localizations.csv`, run `make lang`. Use
   `trans.<key>` or `context.l10n.<key>`.
+- Local storage: go through the **storage seam** (`CoreLocalDataManager` /
+  `LocalDataManager`); SharedPreferences/FlutterSecureStorage are private
+  state inside it. Hive is available as an optional dep but no default
+  store ships with the template.
 - Codegen: `make gen_all` after touching `@freezed`, `@RestApi`,
-  `@Injectable`, `@HiveType`, `_StateData`, etc.
+  `@Injectable`, `@FlRouteProvider`, optional `@HiveType`, `_StateData`, etc.
 
 ## Reference docs
 

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -19,12 +19,12 @@ OpenCode, Claude Code, Cursor, GitHub Copilot, Windsurf, and others.
 |---|---|
 | [`behavioral-guardrails`](./skills/behavioral-guardrails/SKILL.md) | Clarify ambiguity, avoid overengineering, keep diffs surgical, verify outcomes |
 | [`module-scaffold`](./skills/module-scaffold/SKILL.md) | Scaffold a feature module via `make run_module_generator` or by hand |
-| [`bloc-pattern`](./skills/bloc-pattern/SKILL.md) | `AppBlocBase` + abstract state hierarchy + freezed `_StateData` |
+| [`bloc-pattern`](./skills/bloc-pattern/SKILL.md) | `CoreBlocBase` + abstract state hierarchy + freezed `_StateData` |
 | [`bus-event`](./skills/bus-event/SKILL.md) | Cross-feature synchronization with `EventBusManager` |
 | [`extension-action`](./skills/extension-action/SKILL.md) | `*.action.dart` part-of screen for handlers + bloc listeners |
 | [`route-config`](./skills/route-config/SKILL.md) | `IRoute` / `CustomRouter` (from core) + `BuildContext` coordinator |
 | [`theme-usage`](./skills/theme-usage/SKILL.md) | `context.themeColor` + `context.textTheme` from fl_theme |
-| [`data-layer`](./skills/data-layer/SKILL.md) | Freezed DTO + Retrofit + hive_ce + repository wired through injectable |
+| [`data-layer`](./skills/data-layer/SKILL.md) | Freezed DTO + Retrofit + storage seam + repository wired through injectable (Hive optional) |
 | [`error-handling`](./skills/error-handling/SKILL.md) | Throw → `CoreBlocBase.onError` → `StateBase` `ErrorType` router |
 | [`localization`](./skills/localization/SKILL.md) | CSV → ARB → generated `AppLocalizations` |
 | [`code-generation`](./skills/code-generation/SKILL.md) | `make gen_all` / `make gen_<scope>` / `make lang` |
@@ -43,6 +43,8 @@ These skills assume the structure shipped by the template:
 - Cross-feature synchronization via `BusEvent` + `EventBusManager`.
 - Routing via `IRoute` + `CustomRouter` from `core/lib/presentation/route/`
   (re-exported via `package:core/core.dart`).
+- Local persistence via the storage seam (`CoreLocalDataManager` /
+  `LocalDataManager`) — never raw `SharedPreferences` / `FlutterSecureStorage`.
 - Theming via `plugins/fl_theme/` — Material 3 token names plus
   `AppTextTheme` extras; reach colors with `context.themeColor`.
 - Localization via CSV in `apps/main/lib/l10n/localizations.csv`,

--- a/.agents/skills/bloc-pattern/SKILL.md
+++ b/.agents/skills/bloc-pattern/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bloc-pattern
-description: Implements BLoC state management using AppBlocBase, an abstract State hierarchy, and a freezed _StateData
+description: Implements BLoC state management using CoreBlocBase, an abstract State hierarchy, and a freezed _StateData
 license: MIT
 compatibility: all
 metadata:
@@ -20,12 +20,12 @@ metadata:
 
 This template uses a specific bloc shape that is **not** the typical "freezed sealed union" pattern. The state hierarchy is hand-written `abstract class` siblings sharing a freezed `_StateData`; events are hand-written subclasses of an abstract event. Follow this shape exactly — `state.copyWith<T>()` and the `_factories` map depend on it.
 
-1. Bloc extends `AppBlocBase<E, S>` (defined in `apps/main/lib/presentation/base/bloc_base.dart`, ultimately `CoreBlocBase` from `core/`).
+1. Bloc extends `CoreBlocBase<E, S>` (defined in `core/lib/presentation/base/bloc/bloc_base.dart`). The template no longer ships a separate `AppBlocBase` layer — feature blocs inherit `CoreBlocBase` directly. If an app needs cross-cutting bloc behavior (analytics fan-out, common error mapping, feature-flag plumbing), it can reintroduce an `AppBlocBase<E, S> extends CoreBlocBase<E, S>` under `apps/main/lib/presentation/base/` and have feature blocs extend that instead. Don't add the indirection pre-emptively — an empty layer is what was removed.
 2. Bloc is annotated `@Injectable()`. Use `@factoryParam` for runtime args.
 3. Event classes inherit from a single abstract `<X>Event` — no freezed union.
 4. State classes inherit from a single abstract `<X>State` and share a freezed `_StateData`. The base provides `copyWith<T extends <X>State>({_StateData? data})` backed by a `_factories` map.
 5. `_StateData` is `@freezed sealed class _StateData with _$StateData` — generator declares it that way; do not change.
-6. Imports: `package:core/core.dart` (re-exports flutter_bloc, AppBlocBase, helpers), `package:freezed_annotation/freezed_annotation.dart`, `package:injectable/injectable.dart`.
+6. Imports: `package:core/core.dart` (re-exports flutter_bloc, `CoreBlocBase`, helpers), `package:freezed_annotation/freezed_annotation.dart`, `package:injectable/injectable.dart`.
 7. Run `make gen_all` after editing — `<feature>_bloc.freezed.dart` is generated.
 
 ## Reference: bloc file (`<feature>_bloc.dart`)
@@ -38,14 +38,13 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
 
 import '../../../../domain/usecases/<feature>/<feature>_usecase.dart';
-import '../../../base/base.dart';
 
 part '<feature>_bloc.freezed.dart';
 part '<feature>_event.dart';
 part '<feature>_state.dart';
 
 @Injectable()
-class FeatureBloc extends AppBlocBase<FeatureEvent, FeatureState> {
+class FeatureBloc extends CoreBlocBase<FeatureEvent, FeatureState> {
   final FeatureUsecase _usecase;
 
   FeatureBloc(
@@ -127,7 +126,9 @@ class GetFeatureEvent extends FeatureEvent {
 class LoadMoreEvent extends FeatureEvent {}
 ```
 
-For events that need to surface a result back to the caller (e.g. login flows), pass a `Completer<T>` on the event and complete it inside the handler. Choose `T` to carry the useful result object when the caller needs refreshed state; avoid returning only `bool` and forcing an immediate duplicate query.
+For events that need to surface a result back to the caller (e.g. login flows), **don't** stash a `Completer<T>` on the event — model the outcome as concrete state subclasses (`LoginSuccess`, `LoginFailed`) and let the screen's `_blocListener` react. The signin module is the canonical example. Reserve the completer pattern for callers that must `await` a single-shot side effect outside the BLoC stream (e.g. a coordinator chain), and even there prefer returning the refreshed domain object from a use case over a `bool`.
+
+Guard re-entry at the top of long-running handlers when the success state is terminal (`if (state is LoginSuccess) return;`). This keeps double-taps idempotent without locking the bloc with extra fields.
 
 ## Loading + error handling
 
@@ -172,7 +173,7 @@ Action files (see `extension-action`) typically use `_blocListener(BuildContext 
 
 ## Checklist
 
-- [ ] Bloc extends `AppBlocBase<E, S>` and is `@Injectable()`.
+- [ ] Bloc extends `CoreBlocBase<E, S>` and is `@Injectable()`.
 - [ ] `<feature>_bloc.dart` declares the three `part` directives (freezed, event, state).
 - [ ] `_StateData` is `@freezed sealed class` and uses `@Default(...)` for non-nullable defaults.
 - [ ] Every concrete state subclass has a matching entry in `_factories`.

--- a/.agents/skills/bus-event/SKILL.md
+++ b/.agents/skills/bus-event/SKILL.md
@@ -161,7 +161,7 @@ Declare a typed subscription, subscribe in the constructor after registering BLo
 ```dart
 @Injectable()
 class RecordsListingBloc
-    extends AppBlocBase<RecordsListingEvent, RecordsListingState> {
+    extends CoreBlocBase<RecordsListingEvent, RecordsListingState> {
   final RecordsUsecase _usecase;
   StreamSubscription<RecordActivityChangedBusEvent>? _eventSubscription;
 

--- a/.agents/skills/code-generation/SKILL.md
+++ b/.agents/skills/code-generation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-generation
-description: Runs build_runner across core, data_source, and apps/main via the makefile after edits to freezed/injectable/retrofit/hive sources
+description: Runs build_runner across core, data_source, and apps/main via the makefile after edits to freezed/injectable/retrofit sources (and the optional Hive type adapters)
 license: MIT
 compatibility: all
 metadata:
@@ -13,7 +13,7 @@ metadata:
 
 ## When to use
 
-After editing any file annotated with `@freezed`, `@JsonSerializable`/`@JsonKey`, `@Injectable`/`@LazySingleton`/`@Singleton`/`@module`, `@RestApi`, `@HiveType`, or that declares a `_StateData` for a bloc.
+After editing any file annotated with `@freezed`, `@JsonSerializable`/`@JsonKey`, `@Injectable`/`@LazySingleton`/`@Singleton`/`@module`, `@RestApi`, `@FlRouteProvider`, the optional `@HiveType`, or that declares a `_StateData` for a bloc.
 
 ## Commands
 
@@ -38,7 +38,7 @@ When you don't know the scope of your change, run `make gen_all`. It's slower bu
 | Pattern | Producer | Hand-edit? |
 |---|---|---|
 | `*.freezed.dart` | freezed | Never |
-| `*.g.dart` | json_serializable, retrofit, hive_ce | Never |
+| `*.g.dart` | json_serializable, retrofit (and hive_ce, when used) | Never |
 | `*.config.dart` | injectable | Never |
 | `app_localizations*.dart` | flutter intl tooling via `make lang` | Never |
 
@@ -75,7 +75,7 @@ git diff --exit-code -- '**/*.freezed.dart' '**/*.g.dart' '**/*.config.dart' \
 
 ## Checklist
 
-- [ ] After adding/changing a `@freezed`/`@Injectable`/`@RestApi`/`@HiveType` source, `make gen_all` (or the narrow target) was run.
+- [ ] After adding/changing a `@freezed`/`@Injectable`/`@RestApi`/`@FlRouteProvider`/(optional `@HiveType`) source, `make gen_all` (or the narrow target) was run.
 - [ ] After editing `localizations.csv`, `make lang` was run.
 - [ ] No hand-edited generated files in the diff.
 - [ ] All generated files are staged for commit.

--- a/.agents/skills/data-layer/SKILL.md
+++ b/.agents/skills/data-layer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-layer
-description: Builds the data layer with Freezed DTOs, Retrofit clients, hive_ce local stores, and repositories wired through injectable
+description: Builds the data layer with Freezed DTOs, Retrofit clients, the storage-seam local data manager, and repositories wired through injectable
 license: MIT
 compatibility: all
 metadata:
@@ -23,10 +23,11 @@ metadata:
 |---|---|---|
 | DTO + value classes | `freezed` + `freezed_annotation` + `json_serializable` | `*.freezed.dart`, `*.g.dart` |
 | REST client | `retrofit` + `dio` + `retrofit_generator` | `*.g.dart` |
-| Local store | `hive_ce` + `hive_ce_generator` | `*.g.dart` |
+| Key/value persistence | `shared_preferences` + `flutter_secure_storage` (private state behind the storage seam) | — |
+| Local store (optional, on demand) | `hive_ce` + `hive_ce_generator` | `*.g.dart` |
 | DI | `injectable` + `injectable_generator` | `*.config.dart` |
 
-The shared module `modules/data_source/` exposes Retrofit + hive_ce plumbing; per-feature clients live there or, for app-specific endpoints, under `apps/main/lib/data/data_source/`. Models that are shared across apps go in `core/lib/data/models/`.
+The shared module `modules/data_source/` exposes Retrofit plumbing; per-feature clients live there or, for app-specific endpoints, under `apps/main/lib/data/data_source/`. Models that are shared across apps go in `core/lib/data/models/`. Local persistence flows through the **storage seam** (see below) — go through it rather than reaching for raw `SharedPreferences` or `FlutterSecureStorage` instances in presentation or feature code.
 
 Run `make gen_all` after edits.
 
@@ -119,21 +120,29 @@ Future<UploadResponse> upload(
 );
 ```
 
-## Hive local store
+## Storage seam (local persistence)
 
-For simple key/value caches use a hive_ce-backed data source. Generated boxes live under `data_source/local/` and surface a single class consumed by the repository.
+See `CONTEXT.md` §Storage seam for the definition. Operational rules:
 
-```dart
-@HiveType(typeId: 7)
-class UserHive extends HiveObject {
-  UserHive({required this.id, required this.name});
+- Bind the app-scope `LocalDataManager` **and** the `@module` bridge that exposes `CoreLocalDataManager` as `@lazySingleton`. The seam holds in-memory caches (e.g. `_memCacheToken`); a factory binding silently desyncs every consumer.
+- Warm async-only fields once during app init (`await injector<CoreLocalDataManager>().token;`) so the synchronous `isAuthenticated` getter is usable from `GoRoute.redirect`.
+- Add a new persisted field by extending the seam interface — don't add a parallel preferences helper.
 
-  @HiveField(0) final String id;
-  @HiveField(1) final String name;
-}
-```
+## Mock remote source
 
-Don't reuse a `typeId` — pick a unique one across the app.
+See `CONTEXT.md` §Mock remote source for the definition. `MockAuthRemoteSource` is the shipped example: an `@injectable` class with no separate interface, injected directly into `AuthRepositoryImpl`. Downstream apps swap it by defining `RetrofitAuthRemoteSource implements MockAuthRemoteSource` and rebinding — the repository depending on the mock keeps compiling.
+
+Rules when introducing one:
+
+- Keep the contract narrow — one `Future<DomainModel?>` (or domain entity) per operation.
+- Return the refreshed domain object, not a `bool`. Callers that need to update state shouldn't have to issue a second read.
+
+## Hive local store (optional)
+
+Reach for the storage seam first. Only introduce a Hive box when you need typed collections beyond key/value scope. Rules:
+
+- Pick a unique `@HiveType(typeId: …)`; never re-use a deleted `@HiveField(n)` index.
+- Register the adapter in the DI module that owns the box.
 
 ## Local storage APIs
 
@@ -143,30 +152,37 @@ When a mutation produces data the caller needs, return the updated domain result
 
 ## Repository
 
-Repositories accept the API client (and optionally a local data source) by constructor and decide cache/refresh policy. They are the only layer feature blocs depend on.
+Repositories accept the API client (or a remote source) by constructor and are the only layer feature blocs depend on.
+
+The module-generator's `repository.impl.dart` template uses the `DataRepository` mixin, which exposes `restApi` (a `RestApiRepository` reached via DI) for shared transport calls, and wraps the call in `try/on Exception` so the impl can translate transport errors into domain errors before they reach the use case:
 
 ```dart
+import 'package:core/core.dart';
 import 'package:injectable/injectable.dart';
 
-import '../api/user_api_client.dart';
+import '../../domain/repositories/user_repository.dart';
 import '../models/user_model.dart';
 
-@LazySingleton(as: UserRepository)
-class UserRepositoryImpl implements UserRepository {
-  UserRepositoryImpl(this._api);
-
-  final UserApiClient _api;
-
+@Injectable(as: UserRepository)
+class UserRepositoryImpl with DataRepository implements UserRepository {
   @override
-  Future<UserModel> getUser(String id) => _api.getUser(id);
-
-  @override
-  Future<List<UserModel>> getUsers({int page = 1, int limit = 20}) =>
-      _api.getUsers(page: page, limit: limit);
+  Future<User> getUser(String id) async {
+    try {
+      final dto = await restApi.getUser(id);
+      return dto.toEntity();
+    } on Exception catch (error, stackTrace) {
+      // Wrap as NotFoundError / NetworkError / etc. so use cases can
+      // switch on intent instead of catching raw DioException.
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+  }
 }
 ```
 
-Errors surface as `DioException` and are translated by the screen-level error handler (see `error-handling`). Don't wrap them at the repository layer unless you need a domain-specific failure type.
+Two rules the template encodes:
+
+- `with DataRepository implements XRepository` — `DataRepository` is a mixin, not a base class. Don't extend it.
+- DTOs stop at the repository boundary; return domain entities (use a `toEntity()` mapper or equivalent). When a repository forwards a single endpoint with no mapping needed, keep it shallow — don't invent an entity layer for its own sake.
 
 ## DI
 
@@ -195,7 +211,9 @@ abstract class ApiModule {
 - Mutable lists/maps in DTOs (drop the default and end up with nullables).
 - Repositories making `Dio` calls directly, bypassing Retrofit.
 - Forgetting `part 'foo.g.dart';` — Retrofit won't compile.
-- Reusing `@HiveType(typeId: …)` across types.
+- Reaching into `SharedPreferences` / `FlutterSecureStorage` from presentation or feature code instead of going through the storage seam.
+- Binding `LocalDataManager` / `CoreLocalDataManager` as `@Injectable()` (factory) — the in-memory token cache silently desyncs across consumers. Must be `@lazySingleton`.
+- Reusing `@HiveType(typeId: …)` across types when the optional Hive path is used.
 
 ## Related
 

--- a/.agents/skills/data-reviewer/SKILL.md
+++ b/.agents/skills/data-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-reviewer
-description: Reviews data-layer changes — Freezed DTOs, Retrofit clients, hive_ce stores, and repositories — against the template's conventions
+description: Reviews data-layer changes — Freezed DTOs, Retrofit clients, the storage seam, optional hive_ce stores, and repositories — against the template's conventions
 license: MIT
 compatibility: all
 metadata:
@@ -36,7 +36,18 @@ metadata:
 - [ ] `Multipart` endpoints declared with `@Multipart` and `@PartFile()`.
 - [ ] No `try/catch` in the client; let `DioException` propagate.
 
-### Hive stores
+### Storage seam (local persistence)
+
+See `data-layer` §Storage seam for rationale.
+
+- [ ] New persisted fields land on the existing seam (`CoreLocalDataManager` / `LocalDataManager`), not on a fresh helper type.
+- [ ] App-scope `LocalDataManager` and its `@module` bridge are both `@lazySingleton`.
+- [ ] No raw `SharedPreferences` / `FlutterSecureStorage` reads in presentation or feature code.
+- [ ] Any new sync getter intended for `GoRoute.redirect` has its async populator awaited once during app init.
+
+### Hive stores (only when actually used)
+
+Most data-layer PRs leave Hive untouched. When a PR does add one:
 
 - [ ] Unique `@HiveType(typeId: …)`. Cross-check the existing types.
 - [ ] `@HiveField(n)` indices are stable; never reuse a deleted index.

--- a/.agents/skills/flutter-reviewer/SKILL.md
+++ b/.agents/skills/flutter-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flutter-reviewer
-description: Reviews UI-layer changes — screens, blocs, widgets, routes — against the template's StateBase + AppBlocBase + fl_theme conventions
+description: Reviews UI-layer changes — screens, blocs, widgets, routes — against the template's StateBase + CoreBlocBase + fl_theme conventions
 license: MIT
 compatibility: all
 metadata:
@@ -19,7 +19,7 @@ metadata:
 
 ### Bloc shape
 
-- [ ] Bloc extends `AppBlocBase<E, S>` (not `Bloc`/`Cubit` directly) and is `@Injectable()`.
+- [ ] Bloc extends `CoreBlocBase<E, S>` (not `Bloc`/`Cubit` directly) and is `@Injectable()`.
 - [ ] `<feature>_bloc.dart` has the three `part` directives (freezed/event/state) in the right order.
 - [ ] `_StateData` is `@freezed sealed class` with `@Default(...)` on collections.
 - [ ] Concrete state classes are `extends FeatureState` (abstract base), **not** a freezed union — and every concrete class is registered in `_factories`.
@@ -45,7 +45,8 @@ metadata:
 - [ ] `extraFromUrlQueries` set when the screen should be deep-linkable.
 - [ ] Required typed extras use `buildRequiredRouteExtra<T>` or equivalent shared guard instead of repeated unsafe casts.
 - [ ] App-level route aggregation uses `buildFlGoRouter` with the relevant `IRoute` providers.
-- [ ] Coordinator extension on `BuildContext` exposes typed `goToX`, all taking a `PushBehavior`.
+- [ ] Coordinator extension is present **only** when the module is compound or has non-trivial entry logic; simple one-screen modules push the route name directly.
+- [ ] When a coordinator exists, it exposes typed `goToX` on `BuildContext`, all taking a `PushBehavior`, and uses `Args(...).adaptiveArguments` rather than the retired `adaptive`.
 - [ ] No direct `package:go_router/go_router.dart` imports in feature code.
 
 ### Theming

--- a/.agents/skills/module-scaffold/SKILL.md
+++ b/.agents/skills/module-scaffold/SKILL.md
@@ -44,9 +44,9 @@ After generating, run `make gen_all` so freezed/injectable code is emitted, then
 
 ```
 apps/main/lib/presentation/modules/<feature>/
-├── <feature>.dart                # Barrel: exports route/bloc/screen/coordinator
+├── <feature>.dart                # Barrel: exports route/bloc/screen (+ coordinator if compound)
 ├── <feature>_route.dart          # IRoute → CustomRouter<Args>
-├── <feature>_coordinator.dart    # extension on BuildContext
+├── <feature>_coordinator.dart    # ONLY for compound modules / non-trivial entry — see CONTEXT.md
 ├── bloc/
 │   ├── <feature>_bloc.dart       # part directives for event/state/freezed
 │   ├── <feature>_event.dart      # abstract class + concrete events
@@ -56,6 +56,8 @@ apps/main/lib/presentation/modules/<feature>/
     ├── <feature>.action.dart     # part of screen — handlers/listeners
     └── widgets/                  # screen-local widgets (optional)
 ```
+
+The module generator omits the coordinator file when the chosen template's source map lacks a `coordinator` key (see `tools/module_generator/lib/generator/module_generator_ext.dart`). Simple modules call `pushBehavior.push(context, FeatureScreen.routeName)` directly; only compound modules and modules with non-trivial entry logic (arg translation, pre-nav guards) keep a coordinator. A one-line `pushBehavior.push` wrapper is shallow — don't add one.
 
 Domain + data live alongside, not under `presentation/`:
 
@@ -102,9 +104,9 @@ Stick to the names below — `_factories`, `Args`, `routeName`, the part wiring 
 - [ ] Module placed under `lib/presentation/modules/<feature>/`.
 - [ ] Multi-screen feature uses a parent route/coordinator/barrel plus child sub-modules.
 - [ ] Screen extends `StateBase<T>` and has a `static String routeName`.
-- [ ] Bloc extends `AppBlocBase<E, S>` and is `@Injectable()`.
+- [ ] Bloc extends `CoreBlocBase<E, S>` and is `@Injectable()`.
 - [ ] Route extends `IRoute` and wraps the screen in `BlocProvider`.
-- [ ] Coordinator is an extension on `BuildContext` using `PushBehavior`.
+- [ ] If present, the coordinator is an extension on `BuildContext` using `PushBehavior` — added only for compound modules or non-trivial entry logic (see `route-config` §Coordinator).
 - [ ] Route registered in the app's parent `IRoute`.
 - [ ] `make gen_all` run; generated files committed.
 

--- a/.agents/skills/route-config/SKILL.md
+++ b/.agents/skills/route-config/SKILL.md
@@ -151,31 +151,49 @@ class FeatureArgs {
   final Item? initial;
   final String? id;
 
-  FeatureArgs({this.initial, this.id});
+  const FeatureArgs({this.initial, this.id});
 
   factory FeatureArgs.fromUrlParams(Map<String, dynamic> queryParameters) =>
       FeatureArgs(id: asOrNull(queryParameters['id']));
 
   // For web, flatten to a query map; for native, pass the rich object.
-  dynamic get adaptive {
+  // The canonical getter name is `adaptiveArguments` (never `adaptive`).
+  dynamic get adaptiveArguments {
     if (kIsWeb) {
       return {'id': initial?.id ?? id}..removeWhere((_, v) => v.isNullOrEmpty);
     }
     return this;
   }
+
+  /// String form for `GoRoute.redirect` callbacks (and interceptors that
+  /// wrap them) that can't pass a typed `extra`.
+  String toRouteLocation() {
+    return Uri(
+      path: FeatureScreen.routeName,
+      queryParameters: id == null ? null : {'id': id},
+    ).toString();
+  }
 }
 ```
 
-`CustomRouter.buildExtra` resolves either path: a real `Args` object passed via `arguments`, or query params on a deep link.
+`CustomRouter.buildExtra` resolves either path: a real `Args` object passed via `arguments`, or query params on a deep link. Coordinators and interceptors should pick the right Args output for their consumer — `adaptiveArguments` for `pushBehavior.push(arguments: ...)`, `toRouteLocation()` for `redirect` callbacks that must return a string URL.
 
 ## Coordinator (navigation extension)
 
-Every module exposes its routes through a `BuildContext` extension so callers don't typo route paths:
+Coordinators are not free. Add one only for **compound modules** or modules with non-trivial entry logic (parameter translation, pre-nav guards, post-nav handling). A one-line `pushBehavior.push(context, FeatureScreen.routeName)` wrapper is shallow — call the screen route directly from feature code instead. See `CONTEXT.md`.
+
+When a coordinator exists, it owns:
+
+1. `*Args` construction (`adaptiveArguments` for the platform-correct payload).
+2. Pre-nav guards — e.g. signin's coordinator reads the storage seam and short-circuits to the post-login destination when a valid token is already present.
+3. Post-nav handling — refreshing parent state if the child mutated something the caller needs.
 
 ```dart
 import 'package:core/core.dart';
 import 'package:flutter/material.dart';
 
+import '../../../../di/di.dart';
+import '../../../../data/data_source/local/local_data_manager.dart';
 import 'feature.dart';
 
 extension FeatureCoordinator on BuildContext {
@@ -186,24 +204,39 @@ extension FeatureCoordinator on BuildContext {
     return pushBehavior.push(
       this,
       FeatureScreen.routeName,
-      arguments: FeatureArgs(initial: object).adaptive,
-    );
-  }
-
-  Future<T?> goToFeatureById<T>({
-    required String id,
-    PushBehavior pushBehavior = const PushNamedBehavior(),
-  }) async {
-    return pushBehavior.push(
-      this,
-      FeatureScreen.routeName,
-      arguments: FeatureArgs(id: id).adaptive,
+      arguments: FeatureArgs(initial: object).adaptiveArguments,
     );
   }
 }
 ```
 
-Callers: `context.goToFeature(object: item)` or `context.goToFeatureById(id: '42')`.
+The authentication coordinator is the canonical pre-nav-guard example — it consults `injector<LocalDataManager>().token` before deciding whether to push signin or jump straight to the post-login destination.
+
+## Auth-gate interceptor
+
+See `CONTEXT.md` §Auth-gate interceptor for the definition. The shipped example lives at `apps/main/lib/presentation/route/auth_gate_route_interceptor.dart` and wraps each protected `CustomRouter`'s `redirect` so token enforcement stays at the plumbing level — feature screens never check auth state in `build`.
+
+```dart
+class AuthGateRouteInterceptor extends RouteProviderInterceptor {
+  static bool _defaultIsProtected(IRoute provider) =>
+      provider is! AuthenticationRoute;
+
+  CustomRouter _guardRouter(CustomRouter router) {
+    final existingRedirect = router.redirect;
+    return router.copyWith(
+      redirect: (context, state) {
+        if (localDataManager.isAuthenticated) {
+          return existingRedirect?.call(context, state);
+        }
+        return SigninRouteArgs(redirectTo: state.uri.toString())
+            .toRouteLocation();
+      },
+    );
+  }
+}
+```
+
+Token presence is read via the **synchronous** `isAuthenticated` getter on the storage seam — `GoRoute.redirect` cannot await. That means the seam's async `token` getter must be warmed once during app init so the in-memory cache is populated before the first navigation (see `data-layer`).
 
 ## Checklist
 
@@ -211,7 +244,8 @@ Callers: `context.goToFeature(object: item)` or `context.goToFeatureById(id: '42
 - [ ] Route extends `IRoute` and uses `CustomRouter<Args>` (typed) when extras are non-null.
 - [ ] Builder wraps the screen in `BlocProvider` and creates the bloc via `injector.get(...)`.
 - [ ] `extraFromUrlQueries` provided when the screen should be deep-linkable.
-- [ ] Coordinator extension exposes typed `goToX` methods, all taking `PushBehavior`.
+- [ ] Coordinator added only for compound modules or modules with non-trivial entry logic — simple modules call `pushBehavior.push(context, routeName)` directly.
+- [ ] When a coordinator exists, it exposes typed `goToX` methods, all taking `PushBehavior`, and passes `Args(...).adaptiveArguments` (not the older `adaptive`).
 - [ ] Route/coordinator methods have concise Dartdoc when they are newly introduced public APIs.
 - [ ] New top-level `IRoute` has `@FlRouteProvider()` and `make gen_main` was run to refresh the generated provider registry.
 - [ ] Route restrictions use runtime `routeProviderInterceptors`, not manual generated-provider lists.

--- a/.agents/teams/development-team.yaml
+++ b/.agents/teams/development-team.yaml
@@ -211,7 +211,7 @@ project_config:
   project_root: .
   conventions:
     - clean_architecture                           # presentation → domain → data
-    - bloc_pattern_with_state_data                 # AppBlocBase + abstract state hierarchy
+    - bloc_pattern_with_state_data                 # CoreBlocBase + abstract state hierarchy
     - freezed_state_data                           # _StateData via @freezed sealed class
     - extension_action_screens                     # *.action.dart part-of screen
     - iroute_navigation_via_core                   # IRoute + CustomRouter from core/, fed into go_router

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Primary libraries and patterns:
 - **State management**: BLoC + Freezed
 - **DI**: Injectable + GetIt (`apps/main/lib/di/di.dart`)
 - **Networking**: Retrofit + Dio via `modules/data_source`
-- **Local storage**: Hive, SharedPreferences, secure storage
+- **Local storage**: storage seam (`CoreLocalDataManager` / `LocalDataManager`) over SharedPreferences + FlutterSecureStorage. `hive_ce` is still a declared dep if a feature genuinely needs a box, but the template no longer ships a default Hive store.
 - **Routing**: project route abstractions under `presentation/route`
 - **Localization**: CSV source files -> ARB -> generated localizations
 
@@ -294,7 +294,7 @@ Follow the repository `bloc-pattern` skill. This template does **not** use the t
 
 Rules:
 
-- Bloc extends `AppBlocBase<E, S>` and is annotated `@Injectable()`.
+- Bloc extends `CoreBlocBase<E, S>` and is annotated `@Injectable()`. Apps that need cross-cutting bloc behavior (analytics, common error mapping, feature-flag plumbing) may introduce an `AppBlocBase<E, S> extends CoreBlocBase<E, S>` under `apps/main/lib/presentation/base/` and have feature blocs extend that instead. Don't add the indirection while it would stay empty.
 - Events are hand-written subclasses of one abstract `<Feature>Event`; do not use Freezed unions for events.
 - States are hand-written subclasses of one abstract `<Feature>State`; do not use `FeatureState.loading()` / `.loaded()` Freezed unions.
 - State subclasses share one Freezed `_StateData` class.
@@ -307,7 +307,7 @@ Reference shape:
 
 ```dart
 @Injectable()
-class FeatureBloc extends AppBlocBase<FeatureEvent, FeatureState> {
+class FeatureBloc extends CoreBlocBase<FeatureEvent, FeatureState> {
   final FeatureUsecase _usecase;
 
   FeatureBloc(@factoryParam Item? initial, this._usecase)


### PR DESCRIPTION
## Summary

Brings `AGENTS.md` and the `.agents/` skill bundle in line with the v2.0 refactor that landed in #25 and the follow-up token-cache + theme-key fixes. No code under `apps/`, `core/`, `modules/`, or `plugins/` is touched — this PR is documentation only.

- **BLoC base.** `AppBlocBase` was retired in v2.0; feature blocs extend `CoreBlocBase` from `package:core/core.dart` directly. The skill, AGENTS.md, INDEX.md, ONBOARDING.md, the reviewer skills, the bus-event snippet, and the team yaml all read consistently. An app-scoped `AppBlocBase<E, S> extends CoreBlocBase<E, S>` is noted as the escape hatch when an app has cross-cutting behavior to attach (analytics, common error mapping, feature flags) — not as the default layer.
- **Storage seam.** New canonical surface: `CoreLocalDataManager` / `LocalDataManager`. Documents the `@lazySingleton` rule on both the app-scope binding and the `@module` bridge, plus the warm-the-token-cache step that lets `GoRoute.redirect` consult a synchronous `isAuthenticated` getter. Hive is now described as optional (the template no longer ships a default box).
- **Module shape.** Coordinators are emitted only for compound modules / non-trivial entry logic, matching the conditional emission in `tools/module_generator/lib/generator/module_generator_ext.dart`. Simple one-screen modules call `pushBehavior.push(context, routeName)` directly. The flutter-reviewer and module-scaffold checklists prefix coordinator lines with "If present,".
- **Route plumbing.** `AuthGateRouteInterceptor` is now the canonical `RouteProviderInterceptor` example in the `route-config` skill, with the `toRouteLocation()` + sync-`isAuthenticated` pairing. `Args.adaptive` was renamed to `Args.adaptiveArguments` in the codebase; the rename is enforced via checklist lines in `route-config` and `flutter-reviewer`.
- **Data layer.** Rewrote the Repository example around the real `DataRepository` *mixin* (`with DataRepository implements XRepository`, calling `await restApi.someMethod(...)`) and the `try / on Exception` error-normalization shape the generator template encodes. Added a Mock remote source section pointing at `MockAuthRemoteSource` as the shipped swap point for downstream backends.
- **Cross-linking.** Several rules that were previously restated near-verbatim across files now cross-link to `CONTEXT.md` or to the canonical SKILL section so future edits land in one place.

## Test plan

This PR ships no executable code. Verification ran against the live source under `apps/main/`, `core/`, and `tools/module_generator/`:

- [x] `CoreBlocBase` location and signature confirmed at `core/lib/presentation/base/bloc/bloc_base.dart`; no stale `AppBlocBase` references remain in `.agents/`, `AGENTS.md`, or `CONTEXT.md`.
- [x] `MockAuthRemoteSource` annotation (`@injectable`, no interface) and `AuthRepositoryImpl` injection confirmed; mock-source docs match.
- [x] `DataRepository` confirmed as a mixin exposing `RestApiRepository get restApi`; repository example matches the generator template at `tools/module_generator/lib/res/templates/repository/repository.impl.dart`.
- [x] `AuthGateRouteInterceptor` snippet verified against `apps/main/lib/presentation/route/auth_gate_route_interceptor.dart`.
- [x] `SigninRouteArgs.adaptiveArguments` and `toRouteLocation()` confirmed against `apps/main/lib/presentation/modules/auth/signin/views/signin_screen.dart`.
- [x] Module generator conditional coordinator emission confirmed at `tools/module_generator/lib/generator/module_generator_ext.dart`.
- [x] Synchronous `isAuthenticated` getter confirmed at `core/lib/data/data_source/local/local_data_manager.dart`.
- [x] No occurrences of `AppBlocBase`, `extends DataRepository`, `restApi(() async`, `@LazySingleton(as: AuthRemoteSource)`, or the bare `.adaptive` getter survive in the doc set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)