### PR TITLE
Preserve Dart trailing-comma formatting

### DIFF
--- a/apps/main/analysis_options.yaml
+++ b/apps/main/analysis_options.yaml
@@ -16,6 +16,9 @@ analyzer:
     - "**.freezed.dart"
     - "lib/l10n/generated/**.dart"
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   rules:
     - unnecessary_const

--- a/apps/main/lib/presentation/modules/auth/signin/views/signin.action.dart
+++ b/apps/main/lib/presentation/modules/auth/signin/views/signin.action.dart
@@ -2,8 +2,7 @@ part of 'signin_screen.dart';
 
 extension SignInAction on SignInScreenState {
   void loginSuccessCallback() {
-    final destination =
-        widget.redirectTo ?? DevModeDashboardScreen.routeName;
+    final destination = widget.redirectTo ?? DevModeDashboardScreen.routeName;
     const PushReplacementNamedBehavior().push(context, destination);
   }
 }

--- a/apps/main/lib/presentation/route/route_providers.config.dart
+++ b/apps/main/lib/presentation/route/route_providers.config.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 
 import 'package:core/presentation/route/core_route.dart' as route_provider_0;
 import 'package:fl_navigation/fl_navigation.dart';

--- a/core/analysis_options.yaml
+++ b/core/analysis_options.yaml
@@ -18,6 +18,9 @@ analyzer:
     - "**.g.dart"
     - "**.freezed.dart"
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   rules:
     - unnecessary_const

--- a/makefile
+++ b/makefile
@@ -257,9 +257,19 @@ gen:
 # Maintenance
 ################################################################################
 
-# Format all Dart code
+# Format hand-written Dart code
 format:
-	$(DART) format .
+	@find . -name '*.dart' \
+		-not -path '*/.dart_tool/*' \
+		-not -path '*/build/*' \
+		-not -path '*/lib/generated/*' \
+		-not -path '*/lib/l10n/generated/*' \
+		-not -path '*/lib/src/l10n/generated/*' \
+		-not -name '*.config.dart' \
+		-not -name '*.freezed.dart' \
+		-not -name '*.g.dart' \
+		-not -name '*.module.dart' \
+		-print0 | xargs -0 $(DART) format
 
 # Run module generator
 run_module_generator:

--- a/modules/data_source/analysis_options.yaml
+++ b/modules/data_source/analysis_options.yaml
@@ -16,6 +16,9 @@ analyzer:
     - "**.g.dart"
     - "**.freezed.dart"
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   rules:
     - unnecessary_const

--- a/plugins/fl_media/example/analysis_options.yaml
+++ b/plugins/fl_media/example/analysis_options.yaml
@@ -9,6 +9,9 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/plugins/fl_navigation/analysis_options.yaml
+++ b/plugins/fl_navigation/analysis_options.yaml
@@ -15,6 +15,9 @@ analyzer:
     - "lib/src/l10n/generated/**.dart"
     - "**.g.dart"
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   rules:
     - unnecessary_const

--- a/plugins/fl_navigation/lib/src/route_provider_generator.dart
+++ b/plugins/fl_navigation/lib/src/route_provider_generator.dart
@@ -383,6 +383,7 @@ String _buildFileContent(
 
   final buffer = StringBuffer()
     ..writeln('// GENERATED CODE - DO NOT MODIFY BY HAND')
+    ..writeln('// dart format off')
     ..writeln();
   for (final importDirective in packageImports) {
     buffer.writeln(importDirective);

--- a/plugins/fl_navigation/test/route_provider_generator_test.dart
+++ b/plugins/fl_navigation/test/route_provider_generator_test.dart
@@ -196,6 +196,7 @@ class FeatureRoute extends IRoute {}
           ],
         );
 
+        expect(content, contains('// dart format off'));
         expect(content, contains('IRoute get featureRoute =>'));
         expect(content, contains('IRoute get featureRoute2 =>'));
         expect(content, contains('      featureRoute,'));

--- a/plugins/fl_theme/analysis_options.yaml
+++ b/plugins/fl_theme/analysis_options.yaml
@@ -15,6 +15,9 @@ analyzer:
     - "lib/src/l10n/generated/**.dart"
     - "**.g.dart"
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   rules:
     - unnecessary_const

--- a/plugins/fl_theme/example/analysis_options.yaml
+++ b/plugins/fl_theme/example/analysis_options.yaml
@@ -9,6 +9,9 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/plugins/fl_ui/analysis_options.yaml
+++ b/plugins/fl_ui/analysis_options.yaml
@@ -14,6 +14,9 @@ analyzer:
     - lib/src/di/di.config.dart
     - "**.g.dart"
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   rules:
     - unnecessary_const

--- a/plugins/fl_ui/example/analysis_options.yaml
+++ b/plugins/fl_ui/example/analysis_options.yaml
@@ -9,6 +9,9 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/plugins/fl_utils/analysis_options.yaml
+++ b/plugins/fl_utils/analysis_options.yaml
@@ -14,6 +14,9 @@ analyzer:
     - lib/di/di.config.dart
     - "**.g.dart"
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   rules:
     - unnecessary_const

--- a/plugins/fl_utils/example/analysis_options.yaml
+++ b/plugins/fl_utils/example/analysis_options.yaml
@@ -9,6 +9,9 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/tools/module_generator/analysis_options.yaml
+++ b/tools/module_generator/analysis_options.yaml
@@ -21,6 +21,9 @@ analyzer:
     missing_return: error
     dead_code: info
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   rules:
     - always_declare_return_types

--- a/tools/module_generator/lib/generator/generate_app_identifier.dart
+++ b/tools/module_generator/lib/generator/generate_app_identifier.dart
@@ -95,13 +95,15 @@ class AndroidConfigDocument extends ConfigDocument {
 
   @override
   String get contentFile {
-    return document.entries.map((e) {
-      final key = e.key.toLowerCase();
-      return '''# ${e.key}
+    return document.entries
+        .map((e) {
+          final key = e.key.toLowerCase();
+          return '''# ${e.key}
 app.$key.name=${e.value.name}
 app.$key.package=${e.value.package}
 ''';
-    }).join('\n');
+        })
+        .join('\n');
   }
 }
 
@@ -112,15 +114,17 @@ class IOSConfigDocument extends ConfigDocument {
 
   @override
   String get contentFile {
-    return document.entries.map((e) {
-      final prefix = e.key.toUpperCase();
-      return '''// ${e.key}
+    return document.entries
+        .map((e) {
+          final prefix = e.key.toUpperCase();
+          return '''// ${e.key}
 ${prefix}_APP_DISPLAY_NAME=${e.value.name}
 ${prefix}_PRODUCT_BUNDLE_IDENTIFIER=${e.value.package}
 ${prefix}_PROVISIONING_PROFILE_SPECIFIER=${e.value.provisioningProfileSpecifier ?? ''}
 ${prefix}_DEVELOPMENT_TEAM=${e.value.teamId ?? ''}
 ''';
-    }).join('\n');
+        })
+        .join('\n');
   }
 }
 


### PR DESCRIPTION
## Summary
- Configure package formatter settings to preserve trailing-comma layouts.
- Update `make format` to format hand-written Dart files while skipping generated outputs.
- Teach the route-provider generator to emit `// dart format off` so generated registries do not drift.

## Test plan
- [x] `make -C /Users/admin/personal/projects/flutter/flutter_base_structure format`
- [x] `cd /Users/admin/personal/projects/flutter/flutter_base_structure/plugins/fl_navigation; fvm flutter test test/route_provider_generator_test.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)