### PR TITLE
chore: Clarify flutter-skill E2E guidance

### DIFF
--- a/.agents/skills/behavioral-guardrails/SKILL.md
+++ b/.agents/skills/behavioral-guardrails/SKILL.md
@@ -79,6 +79,7 @@ Prefer concrete checks:
 - `fvm flutter analyze --no-pub` from affected packages.
 - UI smoke tests for user-facing flow changes when a device/browser is available.
 - Use Playwright MCP for Flutter web route/playground E2E checks only when the user requests E2E or Playwright verification.
+- Use flutter-skill MCP for native E2E/spec verification only when requested; start the debug session yourself when the simulator/emulator and local Flutter toolchain are available.
 
 ## 5. Flutter base source-of-truth rules
 

--- a/.agents/skills/flutter-reviewer/SKILL.md
+++ b/.agents/skills/flutter-reviewer/SKILL.md
@@ -66,6 +66,7 @@ metadata:
 - [ ] JSON import/export, invalid JSON errors, preset switching, and preview-only toggles are covered by tests or smoke checks.
 - [ ] Preview surfaces cover disabled/error/menu/navigation states when the playground claims to demonstrate component theming.
 - [ ] When the user requested E2E or Playwright verification, a real browser smoke check was run for web playground changes, preferably with Playwright MCP, including console warnings/errors.
+- [ ] When the user requested native E2E/spec verification, a debug build was driven with flutter-skill MCP, starting the session yourself when local prerequisites were available.
 - [ ] When E2E is requested for web route examples, route changes cover direct path URLs and observable route state.
 
 ### Performance

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -62,7 +62,15 @@ For assertions, verify the behavior the user requested: URL changes, visible/sem
 
 ### Native (flutter_skill)
 
-Use the flutter-skill MCP only when the user asks for E2E or spec verification on a native debug build. Prerequisites: MCP loaded since the last Claude Code restart, a booted simulator/emulator, and a debug build of the right flavor running (`fvm flutter run -t lib/main_dev.dart --flavor dev -d <id>`). If any are missing, ask — don't auto-launch.
+Use the flutter-skill MCP only when the user asks for E2E or spec verification on a native debug build, same rule as Playwright. The project already includes the `flutter_skill` dep in `apps/main`, the debug-only binding in `AppDelegate.run`, and the `flutter-skill` MCP server registration in `.mcp.json`.
+
+If no debug session is running, start one yourself when a simulator/emulator is available and the local Flutter/FVM toolchain is available:
+
+```bash
+fvm flutter run -t lib/main_dev.dart --flavor dev -d <id>
+```
+
+Ask the user only for prerequisites you cannot perform yourself, such as installing/loading the `flutter-skill` MCP server or booting a missing simulator.
 
 See [`AGENTS.md`](../../../AGENTS.md) under "E2E testing (flutter_skill)" for the version pin and wrapper script.
 


### PR DESCRIPTION
## Summary
- Align repo-local testing guidance with the flutter-skill native E2E workflow
- Tell agents to start debug sessions themselves when local simulator/toolchain prerequisites are available
- Add native E2E/spec verification checks to guardrail and reviewer skills

## Test plan
- [ ] Not run (documentation-only guidance changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)