### PR TITLE
Add fl_ui widget previews

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -13,6 +13,7 @@ One-line index of every skill under [`./skills/`](./skills/).
 | [`extension-action`](./skills/extension-action/SKILL.md) | `*.action.dart` for screen handlers | Splitting handlers out of a bloated screen |
 | [`route-config`](./skills/route-config/SKILL.md) | `IRoute` + `CustomRouter` + optional coordinator | Wiring navigation |
 | [`theme-usage`](./skills/theme-usage/SKILL.md) | `context.themeColor` + `context.textTheme` | Styling a widget |
+| [`flutter-widget-preview`](./skills/flutter-widget-preview/SKILL.md) | Official `@Preview` / `flutter widget-preview` workflow | Previewing or showcasing Flutter widgets |
 | [`data-layer`](./skills/data-layer/SKILL.md) | Freezed DTO + Retrofit + storage seam + repo (Hive optional) | Talking to an API or local store |
 | [`flutter-dependency-injection`](./skills/flutter-dependency-injection/SKILL.md) | Injectable + GetIt composition boundaries and DI review | Wiring or reviewing dependencies |
 | [`error-handling`](./skills/error-handling/SKILL.md) | `CoreBlocBase.onError` + `ErrorType` router | Deciding what to do with a thrown error |
@@ -42,6 +43,7 @@ Reviewing data-layer PR?       → data-reviewer
 Reviewing UI PR?               → flutter-reviewer
 Custom error UX?               → error-handling
 Styling questions?             → theme-usage
+Previewing a widget?           → flutter-widget-preview → theme-usage
 ```
 
 ## Related

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -24,6 +24,7 @@ OpenCode, Claude Code, Cursor, GitHub Copilot, Windsurf, and others.
 | [`extension-action`](./skills/extension-action/SKILL.md) | `*.action.dart` part-of screen for handlers + bloc listeners |
 | [`route-config`](./skills/route-config/SKILL.md) | `IRoute` / `CustomRouter` (from core) + `BuildContext` coordinator |
 | [`theme-usage`](./skills/theme-usage/SKILL.md) | `context.themeColor` + `context.textTheme` from fl_theme |
+| [`flutter-widget-preview`](./skills/flutter-widget-preview/SKILL.md) | Official Flutter Widget Previewer with `@Preview` and `flutter widget-preview start` |
 | [`data-layer`](./skills/data-layer/SKILL.md) | Freezed DTO + Retrofit + storage seam + repository wired through injectable (Hive optional) |
 | [`flutter-dependency-injection`](./skills/flutter-dependency-injection/SKILL.md) | Injectable + GetIt boundaries, lifetimes, contracts, codegen, and DI tests |
 | [`error-handling`](./skills/error-handling/SKILL.md) | Throw → `CoreBlocBase.onError` → `StateBase` `ErrorType` router |

--- a/.agents/skills/flutter-widget-preview/SKILL.md
+++ b/.agents/skills/flutter-widget-preview/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: flutter-widget-preview
+description: Creates and runs previews with Flutter's official Widget Previewer using `@Preview` from `package:flutter/widget_previews.dart`. Use when the user asks to preview, showcase, inspect, or smoke-test a Flutter widget in the Widget Previewer.
+license: MIT
+compatibility: all
+metadata:
+  audience: flutter-developers
+  framework: flutter
+  pattern: widget-preview
+---
+
+# Flutter Widget Preview Skill
+
+## When to use
+
+- Previewing a new or changed Flutter widget interactively.
+- Adding `@Preview` coverage for reusable UI, theme, or core widgets.
+- Smoke-testing visual states without launching the full app.
+
+## Tooling model
+
+Flutter Widget Previewer renders widgets in Chrome, separate from the app. It requires Flutter 3.35+; IDE support requires Flutter 3.38+. The API is experimental, so verify https://docs.flutter.dev/tools/widget-previewer before broad preview infrastructure changes.
+
+Do not introduce Widgetbook, Storybook, or custom preview apps unless the user explicitly asks.
+
+## Add a preview
+
+Import the preview API in the package that owns the widget:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter/widget_previews.dart';
+
+@Preview(name: 'Feature card')
+Widget featureCardPreview() => const FeatureCard();
+```
+
+`@Preview` can annotate top-level functions, static methods, and public `Widget` constructors/factories with no required arguments. Functions and methods must return `Widget` or `WidgetBuilder`.
+
+Use deterministic, non-secret preview data. Keep preview-only state outside production config and generated files.
+
+## Configure previews
+
+Use `@Preview` parameters instead of new infrastructure:
+
+- `name` and `group` for discoverability.
+- `size` for realistic constraints, especially mobile widths and unconstrained widgets.
+- `textScaleFactor` for accessibility checks.
+- `brightness` for light/dark variants.
+- `wrapper` for required ancestors such as `MaterialApp`, localization, providers, or inherited state.
+- `theme` and `localizations` for Material/Cupertino theme and locale configuration.
+
+Apply multiple `@Preview` annotations to one function for state variants. Use custom `Preview` or `MultiPreview` annotations only when repeated configuration is already noisy.
+
+## Project wrapper guidance
+
+Match enough production context for the widget to render honestly:
+
+- Add `MaterialApp`/`Scaffold` for Material widgets.
+- Add app localization delegates and supported locales when the widget reads translations.
+- Apply the project theme path when the widget uses `context.themeColor`, `context.textTheme`, or `ScreenForm`.
+- Provide the same BLoC/provider shape the screen expects; prefer focused fake data over broad mocks.
+
+All callback values passed to preview annotations must be public and constant so previewer code generation can read them.
+
+## Run the previewer
+
+From the Flutter package root that contains the previews:
+
+```bash
+fvm flutter widget-preview start
+```
+
+Check `.fvm_cache`; if `USING_FVM=1`, use `fvm flutter`, otherwise use `flutter`. IDEs expose a "Flutter Widget Preview" tab when supported.
+
+Run the previewer yourself when the local Flutter toolchain is available. Ask the user only for setup you cannot perform.
+
+## Limitations and verification
+
+- Native plugins and `dart:io` / `dart:ffi` APIs are unsupported because the previewer uses Flutter Web.
+- Asset loading through `dart:ui` `fromAsset` APIs must use package-based paths such as `packages/my_package/assets/foo.png`.
+- Apply `size` when constraints matter; default unconstrained behavior is not stable.
+- Preview default, loading, empty, error, disabled, long-text, overflow, light/dark, and text-scale states as applicable.
+- Use the previewer controls for zoom, brightness, and hot restart.
+- If E2E/spec verification is requested, use the `testing` skill and `flutter_skill` guidance separately.
+- If you cannot run the previewer, report the exact blocker.
+
+## Related
+
+- [`theme-usage`](../theme-usage/SKILL.md)
+- [`testing`](../testing/SKILL.md)
+- [`behavioral-guardrails`](../behavioral-guardrails/SKILL.md)

--- a/plugins/fl_ui/lib/fl_ui_previews.dart
+++ b/plugins/fl_ui/lib/fl_ui_previews.dart
@@ -1,0 +1,438 @@
+import 'package:fl_theme/fl_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widget_previews.dart';
+
+import 'fl_ui.dart';
+
+final ThemeData _materialLightPreviewTheme = _buildPreviewTheme(
+  Brightness.light,
+);
+final ThemeData _materialDarkPreviewTheme = _buildPreviewTheme(Brightness.dark);
+final PreviewThemeData _previewTheme = PreviewThemeData(
+  materialLight: _materialLightPreviewTheme,
+  materialDark: _materialDarkPreviewTheme,
+);
+
+PreviewThemeData flUiPreviewTheme() => _previewTheme;
+
+Widget flUiPreviewWrapper(Widget child) {
+  return Material(
+    color: Colors.transparent,
+    child: SingleChildScrollView(
+      padding: const EdgeInsets.all(20),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 480),
+          child: child,
+        ),
+      ),
+    ),
+  );
+}
+
+final class FlUiPreview extends MultiPreview {
+  const FlUiPreview({required this.group, required this.size});
+
+  final String group;
+  final Size size;
+
+  @override
+  List<Preview> get previews => const <Preview>[
+    Preview(name: 'Light', brightness: Brightness.light),
+    Preview(name: 'Dark', brightness: Brightness.dark),
+  ];
+
+  @override
+  List<Preview> transform() {
+    return super.transform().map((preview) {
+      final builder = preview.toBuilder()
+        ..group = group
+        ..size = size
+        ..theme = flUiPreviewTheme
+        ..wrapper = flUiPreviewWrapper;
+      return builder.build();
+    }).toList();
+  }
+}
+
+ThemeData _buildPreviewTheme(Brightness brightness) {
+  final isLight = brightness == Brightness.light;
+  return AppTheme.create(
+    AppThemeConfig(
+      designSystem: AppDesignSystem(
+        name: 'fl_ui ${brightness.name}',
+        colors: ThemeColor(
+          primary: isLight ? const Color(0xFF2563EB) : const Color(0xFF60A5FA),
+          secondary: isLight
+              ? const Color(0xFF14B8A6)
+              : const Color(0xFF2DD4BF),
+          brightness: brightness,
+          background: isLight
+              ? const Color(0xFFF8FAFC)
+              : const Color(0xFF0F172A),
+          surface: isLight ? Colors.white : const Color(0xFF1E293B),
+          scaffoldBackgroundColor: isLight
+              ? const Color(0xFFF8FAFC)
+              : const Color(0xFF0F172A),
+          cardBackground: isLight ? Colors.white : const Color(0xFF1E293B),
+          borderColor: isLight
+              ? const Color(0xFFE2E8F0)
+              : const Color(0xFF475569),
+          dividerColor: isLight
+              ? const Color(0xFFE2E8F0)
+              : const Color(0xFF334155),
+        ),
+      ),
+    ),
+  ).theme;
+}
+
+void _ignoreTap() {}
+void _ignoreBool(bool? _) {}
+void _ignoreString(String _) {}
+void _ignoreNullableString(String? _) {}
+void _ignoreStringList(List<String> _) {}
+void _ignoreChipSelection(bool _) {}
+String _stringLabel(String item) => item;
+
+@FlUiPreview(group: 'fl_ui / selection', size: Size(393, 720))
+Widget flUiSelectionPreview() => const _SelectionPreview();
+
+@FlUiPreview(group: 'fl_ui / feedback', size: Size(393, 620))
+Widget flUiFeedbackPreview() => const _FeedbackPreview();
+
+@FlUiPreview(group: 'fl_ui / information', size: Size(393, 680))
+Widget flUiInformationPreview() => const _InformationPreview();
+
+@FlUiPreview(group: 'fl_ui / containers', size: Size(393, 560))
+Widget flUiContainersPreview() => const _ContainersPreview();
+
+class _SelectionPreview extends StatelessWidget {
+  const _SelectionPreview();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _PreviewSection(
+          title: 'Checkboxes',
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              CheckboxWithTitle(
+                title: 'Selected option',
+                value: true,
+                onChanged: _ignoreBool,
+              ),
+              CheckboxWithTitle(
+                title: 'Unselected option',
+                value: false,
+                onChanged: _ignoreBool,
+              ),
+              CheckboxWithTitle(
+                title: 'Disabled option',
+                value: true,
+                enable: false,
+                onChanged: _ignoreBool,
+              ),
+              CheckBoxGroup<String>(
+                items: ['Email', 'Push', 'SMS'],
+                selectedItems: ['Email'],
+                disableItems: ['SMS'],
+                getLabel: _stringLabel,
+                onSelectedChanged: _ignoreStringList,
+              ),
+            ],
+          ),
+        ),
+        SizedBox(height: 16),
+        _PreviewSection(
+          title: 'Radio buttons',
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              RadioButtonWithTitle<String>(
+                title: 'Monthly billing',
+                value: 'monthly',
+                groupValue: 'monthly',
+                onChanged: _ignoreNullableString,
+              ),
+              RadioButtonWithTitle<String>(
+                title: 'Annual billing',
+                value: 'annual',
+                groupValue: 'monthly',
+                onChanged: _ignoreNullableString,
+              ),
+              RadioButtonWithTitle<String>(
+                title: 'Unavailable plan',
+                value: 'legacy',
+                groupValue: 'monthly',
+                enable: false,
+              ),
+              FlRadioGroup<String>(
+                items: ['Small', 'Medium', 'Large'],
+                selectedItem: 'Medium',
+                getLabel: _stringLabel,
+                onSelected: _ignoreString,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _FeedbackPreview extends StatelessWidget {
+  const _FeedbackPreview();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _PreviewSection(
+          title: 'Badges',
+          child: Wrap(
+            spacing: 24,
+            runSpacing: 24,
+            children: [
+              BadgeBox(count: 3, child: Icon(Icons.notifications_outlined)),
+              BadgeBox(
+                count: 127,
+                maxCount: 99,
+                child: Icon(Icons.shopping_bag_outlined),
+              ),
+              BadgeBox(count: 0, child: Icon(Icons.mail_outline)),
+            ],
+          ),
+        ),
+        SizedBox(height: 16),
+        _PreviewSection(
+          title: 'Validation',
+          child: ErrorBox(
+            validation: 'Please select a value',
+            child: _FieldShell(label: 'Project role'),
+          ),
+        ),
+        SizedBox(height: 16),
+        _PreviewSection(
+          title: 'Loading and availability',
+          child: Row(
+            children: [
+              Loading(radius: 12),
+              SizedBox(width: 24),
+              AvailabilityWidget(
+                enable: false,
+                child: _StatusSample(label: 'Disabled action'),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _InformationPreview extends StatelessWidget {
+  const _InformationPreview();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final surface = theme.colorScheme.surface;
+    final divider = theme.dividerColor;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _PreviewSection(
+          title: 'Info items',
+          child: Column(
+            children: [
+              InfoItem(
+                title: 'Customer',
+                value: 'Alex Nguyen',
+                color: surface,
+                divider: ItemDivider.line,
+                dividerColor: divider,
+                required: true,
+              ),
+              InfoItem(
+                title: 'Status',
+                value: StatusBox(
+                  status: 'Active',
+                  color: theme.colorScheme.primary,
+                  textColor: theme.colorScheme.onPrimaryContainer,
+                  bgColor: theme.colorScheme.primaryContainer,
+                ),
+                color: surface,
+                divider: ItemDivider.none,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+        _PreviewSection(
+          title: 'Menu rows',
+          child: Column(
+            children: [
+              MenuItemWidget(
+                title: 'Account settings',
+                icon: const Icon(Icons.person_outline),
+                description: const Text('Updated'),
+                color: surface,
+                divider: ItemDivider.line,
+                onTap: _ignoreTap,
+              ),
+              MenuItemWidget(
+                title: 'Disabled row',
+                icon: const Icon(Icons.lock_outline),
+                color: surface,
+                divider: ItemDivider.none,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+        _PreviewSection(
+          title: 'Indicators',
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Separator(color: divider),
+              const SizedBox(height: 16),
+              Center(
+                child: PageIndicatorWidget(
+                  countItem: 4,
+                  initialPage: 1,
+                  color: divider,
+                  colorActive: theme.colorScheme.primary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ContainersPreview extends StatelessWidget {
+  const _ContainersPreview();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _PreviewSection(
+          title: 'Boxes',
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              BoxColor(
+                color: theme.colorScheme.primaryContainer,
+                borderRadius: BorderRadius.circular(12),
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'BoxColor',
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onPrimaryContainer,
+                  ),
+                ),
+              ),
+              HighlightBoxColor(
+                bgColor: theme.colorScheme.surface,
+                borderColor: theme.colorScheme.primary,
+                child: const Text('HighlightBoxColor'),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+        _PreviewSection(
+          title: 'Chips',
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              ChipItem(
+                selected: true,
+                text: 'Selected',
+                textTheme: textTheme,
+                onTap: _ignoreChipSelection,
+              ),
+              ChipItem(
+                selected: false,
+                text: 'Default',
+                textTheme: textTheme,
+                onTap: _ignoreChipSelection,
+              ),
+              StatusBox(
+                status: 'Pending',
+                color: theme.colorScheme.secondary,
+                textColor: theme.colorScheme.onSecondaryContainer,
+                bgColor: theme.colorScheme.secondaryContainer,
+                hasBorder: true,
+              ),
+              StatusBox(
+                status: 'Done',
+                color: theme.colorScheme.primary,
+                textColor: theme.colorScheme.onPrimaryContainer,
+                bgColor: theme.colorScheme.primaryContainer,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PreviewSection extends StatelessWidget {
+  const _PreviewSection({required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return StoryWidgetBox<Object?>(
+      title: title,
+      builder: (context, _, _) => child,
+    );
+  }
+}
+
+class _FieldShell extends StatelessWidget {
+  const _FieldShell({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return BoxColor(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+      color: Theme.of(context).colorScheme.surface,
+      borderRadius: BorderRadius.circular(8),
+      child: Text(label),
+    );
+  }
+}
+
+class _StatusSample extends StatelessWidget {
+  const _StatusSample({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton(onPressed: _ignoreTap, child: Text(label));
+  }
+}

--- a/plugins/fl_ui/pubspec.yaml
+++ b/plugins/fl_ui/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: none
 
 environment:
   sdk: '>=3.8.0 <4.0.0'
-  flutter: ">=3.32.0"
+  flutter: ">=3.35.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- Add a repo-local Flutter Widget Previewer skill and register it in the agent skill docs.
- Add official `@Preview` coverage for representative `fl_ui` selection, feedback, information, and container widgets.
- Raise the `fl_ui` Flutter lower bound to 3.35.0 for `package:flutter/widget_previews.dart` support.

## Test plan
- [x] `dart format plugins/fl_ui/lib/fl_ui_previews.dart`
- [x] `flutter analyze --no-pub plugins/fl_ui`
- [x] `cd plugins/fl_ui && flutter test --no-pub`
- [x] `flutter widget-preview start --no-pub --web-server` smoke test served HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)