### PR TITLE
Add project edit hooks

### DIFF
--- a/.claude/hooks/format_dart_after_edit.py
+++ b/.claude/hooks/format_dart_after_edit.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+
+
+def _tool_path(payload):
+    tool_input = payload.get("tool_input") or {}
+    tool_response = payload.get("tool_response") or {}
+    return (
+        tool_response.get("filePath")
+        or tool_response.get("file_path")
+        or tool_input.get("file_path")
+        or ""
+    )
+
+
+def _is_generated(path):
+    normalized = path.replace(os.sep, "/")
+    name = os.path.basename(normalized)
+    return (
+        name.endswith((".g.dart", ".freezed.dart", ".config.dart", ".module.dart"))
+        or "/lib/generated/" in normalized
+        or "/lib/l10n/generated/" in normalized
+        or "/lib/src/l10n/generated/" in normalized
+    )
+
+
+try:
+    payload = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+file_path = _tool_path(payload)
+if not file_path.endswith(".dart") or _is_generated(file_path):
+    sys.exit(0)
+
+root_result = subprocess.run(
+    ["git", "rev-parse", "--show-toplevel"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.DEVNULL,
+    text=True,
+    check=False,
+)
+repo_root = root_result.stdout.strip() or os.getcwd()
+
+result = subprocess.run(["make", "-C", repo_root, "format"], check=False)
+sys.exit(result.returncode)

--- a/.claude/hooks/guard_generated_sensitive_files.py
+++ b/.claude/hooks/guard_generated_sensitive_files.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+
+
+def _emit(decision, reason):
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": decision,
+            "permissionDecisionReason": reason,
+        },
+    }))
+
+
+def _relative_path(path):
+    normalized = path.replace("\\", "/")
+    if os.path.isabs(normalized):
+        try:
+            normalized = os.path.relpath(normalized, os.getcwd())
+        except ValueError:
+            pass
+    return normalized.replace("\\", "/").lstrip("./")
+
+
+def _matches(path, patterns):
+    return any(re.search(pattern, path) for pattern in patterns)
+
+
+try:
+    payload = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+file_path = (payload.get("tool_input") or {}).get("file_path") or ""
+if not file_path:
+    sys.exit(0)
+
+rel_path = _relative_path(file_path)
+name = os.path.basename(rel_path)
+
+deny_patterns = [
+    r"(^|/)lib/generated/",
+    r"(^|/)lib/l10n/generated/",
+    r"(^|/)lib/src/l10n/generated/",
+    r"(^|/)intl_[^/]*\.arb$",
+    r"(^|/)(credentials|credential|secrets?|service-account)[^/]*\.(json|ya?ml|txt)$",
+]
+
+ask_patterns = [
+    r"(^|/)app_identifier\.yaml$",
+    r"(^|/)android/app_specific\.properties$",
+    r"(^|/)android/app/build\.gradle$",
+    r"(^|/)android/app/src/main/kotlin/.*/MainActivity\.kt$",
+    r"(^|/)ios/Flutter/AppSpecific\.xcconfig$",
+    r"(^|/)android/keystores/",
+    r"(^|/)ios/signing_res/",
+    r"(^|/)fastlane/",
+    r"(^|/)dist_config\.sh$",
+    r"(^|/)distribution\.sh$",
+    r"(^|/)deploy\.sh$",
+    r"(^|/)CICD_SECRETS_SETUP\.md$",
+    r"(^|/)\.github/workflows/",
+]
+
+if name.endswith((".g.dart", ".freezed.dart", ".config.dart", ".module.dart")) or _matches(rel_path, deny_patterns):
+    _emit(
+        "deny",
+        f"{rel_path} looks generated or secret-bearing. Edit the source of truth and run the appropriate generator instead.",
+    )
+    sys.exit(0)
+
+if name == ".env" or (name.startswith(".env.") and name != ".env.example"):
+    _emit("deny", f"{rel_path} is an environment file and may contain secrets.")
+    sys.exit(0)
+
+if name.endswith((".keystore", ".jks", ".p8", ".p12", ".mobileprovision", ".provisionprofile")):
+    _emit("deny", f"{rel_path} is a signing credential or provisioning artifact.")
+    sys.exit(0)
+
+if _matches(rel_path, ask_patterns):
+    _emit(
+        "ask",
+        f"{rel_path} affects app identity, signing, distribution, or CI. Confirm this high-blast-radius edit is intentional.",
+    )

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/guard_generated_sensitive_files.py\"",
+            "timeout": 5,
+            "statusMessage": "Checking protected files..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/format_dart_after_edit.py\"",
+            "timeout": 120,
+            "statusMessage": "Formatting Dart files..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,11 @@ app.*.map.json
 *.lcov
 *.info
 test/.test_coverage.dart
-.claude/
+# Claude project hooks
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+!.claude/hooks/*.py
 
 # Playwright related
 .playwright-mcp/


### PR DESCRIPTION
## Summary
- Add project Claude Code hooks for Edit/Write operations.
- Block generated/secret-bearing file edits and require confirmation for app identity, signing, distribution, and CI files.
- Run the project formatter after hand-written Dart edits.

## Test plan
- [x] Validate `.claude/settings.json` hook selectors with `jq`.
- [x] Compile hook scripts with `python3 -m py_compile`.
- [x] Pipe-test guard hook for generated, high-blast-radius, and normal files.
- [x] Pipe-test formatter hook skip path for non-Dart files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)