### PR TITLE
feat(dev-mode): add intro and openFrom note to dev dashboard

### DIFF
--- a/core/lib/presentation/modules/dev_mode/dashboard/dev_mode_dashboard_screen.dart
+++ b/core/lib/presentation/modules/dev_mode/dashboard/dev_mode_dashboard_screen.dart
@@ -10,7 +10,16 @@ import '../dev_mode_coordinator.dart';
 
 class DevModeDashboardScreen extends StatefulWidget {
   static const String routeName = '/dev-mode-dashboard';
-  const DevModeDashboardScreen({super.key});
+
+  const DevModeDashboardScreen({
+    super.key,
+    this.openFrom,
+  });
+
+  /// A human-readable note about where this screen was opened from, e.g.
+  /// "Shaking the device". Shown to the QC team so they know they reached an
+  /// intentional tool. Null when the origin is unknown.
+  final String? openFrom;
 
   @override
   State<DevModeDashboardScreen> createState() => _DevModeDashboardScreenState();
@@ -51,23 +60,167 @@ class _DevModeDashboardScreenState extends State<DevModeDashboardScreen> {
       child: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          TextButton(
-            onPressed: context.openLogViewer,
-            child: const Text('Log Viewer'),
+          _DevModeIntro(openFrom: widget.openFrom),
+          const SizedBox(height: 24),
+          _DevModeTile(
+            icon: Icons.article_outlined,
+            title: 'Log Viewer',
+            subtitle: 'Browse the app logs and console output.',
+            onTap: context.openLogViewer,
           ),
-          TextButton(
-            onPressed: context.openNetWorkLogViewer,
-            child: const Text('Network Log Viewer'),
+          _DevModeTile(
+            icon: Icons.lan_outlined,
+            title: 'Network Log Viewer',
+            subtitle: 'Inspect API requests, responses and timing.',
+            onTap: context.openNetWorkLogViewer,
           ),
-          TextButton(
-            onPressed: context.viewDesignSystem,
-            child: const Text('Design System'),
+          _DevModeTile(
+            icon: Icons.palette_outlined,
+            title: 'Design System',
+            subtitle: 'Preview UI components, typography and theme colors.',
+            onTap: context.viewDesignSystem,
           ),
-          TextButton(
-            onPressed: context.openAppConfig,
-            child: const Text('App Config'),
+          _DevModeTile(
+            icon: Icons.settings_outlined,
+            title: 'App Config',
+            subtitle: 'View and override the runtime app configuration.',
+            onTap: context.openAppConfig,
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// An at-a-glance explanation of what this screen is, so QC and testers know
+/// they reached an intentional tool — not a crash or a hidden bug.
+class _DevModeIntro extends StatelessWidget {
+  const _DevModeIntro({required this.openFrom});
+
+  final String? openFrom;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                Icons.developer_mode,
+                color: colorScheme.onPrimaryContainer,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Developer Mode',
+                      style: context.theme.textTheme.titleMedium?.copyWith(
+                        color: colorScheme.onPrimaryContainer,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'A built-in tool for the dev & QC team. Nothing is '
+                      'broken — this screen opens on purpose to help test the '
+                      'app. From here you can inspect logs and network '
+                      'traffic, review the app config, and switch theme or '
+                      'language. Tap back to return to the app.',
+                      style: context.theme.textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onPrimaryContainer,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (openFrom?.isNotEmpty == true) ...[
+            const SizedBox(height: 12),
+            _OpenFromChip(openFrom: openFrom!),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// A small pill showing where the dashboard was opened from.
+class _OpenFromChip extends StatelessWidget {
+  const _OpenFromChip({required this.openFrom});
+
+  final String openFrom;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: colorScheme.onPrimaryContainer.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.touch_app_outlined,
+            size: 16,
+            color: colorScheme.onPrimaryContainer,
+          ),
+          const SizedBox(width: 6),
+          Text(
+            'Opened from: $openFrom',
+            style: context.theme.textTheme.labelMedium?.copyWith(
+              color: colorScheme.onPrimaryContainer,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A single entry in the dev-mode tool list.
+class _DevModeTile extends StatelessWidget {
+  const _DevModeTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.theme.colorScheme;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      clipBehavior: Clip.antiAlias,
+      child: ListTile(
+        leading: Icon(icon, color: colorScheme.primary),
+        title: Text(title),
+        subtitle: Text(subtitle),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: onTap,
       ),
     );
   }

--- a/core/lib/presentation/modules/dev_mode/dev_mode_coordinator.dart
+++ b/core/lib/presentation/modules/dev_mode/dev_mode_coordinator.dart
@@ -11,9 +11,14 @@ import 'log_viewer/network/network_log_viewer_screen.dart';
 
 extension DevModeCoordinator on BuildContext {
   Future<T?> openDevMode<T>({
+    String? openFrom,
     PushBehavior pushBehavior = const PushNamedBehavior(),
   }) async {
-    return pushBehavior.push(this, DevModeDashboardScreen.routeName);
+    return pushBehavior.push(
+      this,
+      DevModeDashboardScreen.routeName,
+      arguments: openFrom,
+    );
   }
 
   Future<T?> openLogViewer<T>({

--- a/core/lib/presentation/modules/dev_mode/dev_mode_route.dart
+++ b/core/lib/presentation/modules/dev_mode/dev_mode_route.dart
@@ -19,7 +19,9 @@ class DevModeRoute extends IRoute {
         path: DevModeDashboardScreen.routeName,
         name: DevModeDashboardScreen.routeName,
         builder: (context, uri, extra) {
-          return const DevModeDashboardScreen();
+          return DevModeDashboardScreen(
+            openFrom: extra is String ? extra : null,
+          );
         },
       ),
       CustomRouter(


### PR DESCRIPTION
Revamp the dev-mode dashboard so QC/testers understand they reached an intentional tool rather than a crash. Adds an explanatory intro card and tool tiles with icons/descriptions, plus an optional `openFrom` note (usually "Shaking the device") threaded through the route and coordinator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)