### PR TITLE
feat(auth): redirect authenticated users off /signin via resolver seam

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,10 @@ _Avoid_: route guard, router middleware.
 The specific `RouteProviderInterceptor` adapter that protects routes by token presence. Wraps each protected router with a `redirect` callback that returns `/signin?redirect=…` when no token is in the storage seam. The canonical demonstration of the interceptor mechanism.
 _Avoid_: auth guard, auth middleware.
 
+**Sign-in redirect resolver** (`SignInRedirectResolver`):
+The app-owned seam that decides where the sign-in flow lands a user once authenticated — the default home route, plus validation of a requested `?redirect=` target (rejecting off-site URLs and loop-backs to sign-in). The router redirect and the **Coordinator** both delegate to it, so the landing policy has one source of truth. The template binds `DefaultSignInRedirectResolver` (lands on the dev-mode dashboard demo); a downstream app rebinds this contract in its `AppModule` to set its own home route.
+_Avoid_: home route constant, post-login navigator, redirect guard.
+
 ### Data layer
 
 **Storage seam**:
@@ -56,7 +60,7 @@ _Avoid_: scaffolding, generator output (when referring to the template itself).
 
 - A **Compound module** owns one **Coordinator**; a **Simple module** does not.
 - A **Route provider** contributes one or more `CustomRouter`s; **Route-provider interceptors** observe each provider's resolution before it becomes a `GoRoute`.
-- The **Auth-gate interceptor** reads token from the **Storage seam** and rewrites resolutions for protected providers.
+- The **Auth-gate interceptor** reads token from the **Storage seam** and rewrites resolutions for protected providers; the **Sign-in redirect resolver** then decides where an authenticated user goes next (and where an already-authenticated user landing on `/signin` is sent).
 - A **Coordinator** may call into the **Storage seam** for pre-nav guards (e.g., skip signin when token already present).
 - A **Mock remote source** is bound at DI composition; the use case it backs treats it identically to a real adapter.
 - **Codegen templates** emit module scaffolding consistent with the **Module shape** vocabulary — Simple modules get no coordinator file; Compound modules do.

--- a/apps/main/build.yaml
+++ b/apps/main/build.yaml
@@ -30,6 +30,7 @@ targets:
           - lib/di/di.dart
           - lib/domain/usecases/auth/auth_usecase.dart
           - lib/presentation/modules/auth/signin/bloc/signin_bloc.dart
+          - lib/presentation/modules/auth/signin/sign_in_redirect_resolver.dart
           - lib/presentation/theme/theme_dialog.dart
       injectable_generator:injectable_config_builder:
         generate_for:
@@ -42,4 +43,5 @@ targets:
           - lib/di/di.dart
           - lib/domain/usecases/auth/auth_usecase.dart
           - lib/presentation/modules/auth/signin/bloc/signin_bloc.dart
+          - lib/presentation/modules/auth/signin/sign_in_redirect_resolver.dart
           - lib/presentation/theme/theme_dialog.dart

--- a/apps/main/lib/di/di.config.dart
+++ b/apps/main/lib/di/di.config.dart
@@ -27,6 +27,8 @@ import '../domain/repositories/auth_credential_source.dart' as _i539;
 import '../domain/repositories/auth_session_store.dart' as _i625;
 import '../domain/usecases/auth/auth_usecase.dart' as _i738;
 import '../presentation/modules/auth/signin/bloc/signin_bloc.dart' as _i893;
+import '../presentation/modules/auth/signin/sign_in_redirect_resolver.dart'
+    as _i844;
 import '../presentation/theme/theme_dialog.dart' as _i83;
 
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -41,6 +43,9 @@ Future<_i174.GetIt> $initGetIt(
   final appDatasourceModule = _$AppDatasourceModule();
   gh.singleton<_i494.SQLiteDatabase>(() => _i833.SQLiteDatabaseImpl());
   gh.factory<_i539.AuthCredentialSource>(() => _i118.MockAuthRemoteSource());
+  gh.lazySingleton<_i844.SignInRedirectResolver>(
+    () => _i844.DefaultSignInRedirectResolver(),
+  );
   gh.lazySingleton<_i655.LocalDataManager>(
     () => _i655.LocalDataManager(
       gh<_i494.SharedPreferences>(),

--- a/apps/main/lib/presentation/modules/auth/authentication_coordinator.dart
+++ b/apps/main/lib/presentation/modules/auth/authentication_coordinator.dart
@@ -1,18 +1,25 @@
 import 'package:core/core.dart';
 import 'package:flutter/material.dart';
 
+import '../../../di/di.dart';
+import 'signin/sign_in_redirect_resolver.dart';
 import 'signin/signin_route_args.dart';
 
 extension AuthenticationCoordinator on BuildContext {
   /// Opens the signin form, threading [returnTo] through as the post-signin
   /// destination. When the storage seam already holds a token the form is
   /// skipped and the caller is sent straight to the destination.
+  ///
+  /// [redirectResolver] resolves and validates the destination; it defaults to
+  /// the bound [SignInRedirectResolver] and is injectable for tests.
   Future<bool?> openSignIn({
     required CoreAppPreferenceData localDataManager,
     String? returnTo,
     PushBehavior pushBehavior = const PushNamedBehavior(),
+    SignInRedirectResolver? redirectResolver,
   }) async {
-    final destination = _signInDestination(returnTo);
+    final resolver = redirectResolver ?? injector<SignInRedirectResolver>();
+    final destination = resolver.resolve(requestedRedirect: returnTo);
     if (localDataManager.isAuthenticated) {
       await pushBehavior.push<dynamic>(this, destination);
       return true;
@@ -30,13 +37,12 @@ extension AuthenticationCoordinator on BuildContext {
   Future<bool?> completeSignIn({
     String? returnTo,
     PushBehavior pushBehavior = const PushReplacementNamedBehavior(),
+    SignInRedirectResolver? redirectResolver,
   }) {
-    return pushBehavior.push<bool>(this, _signInDestination(returnTo));
+    final resolver = redirectResolver ?? injector<SignInRedirectResolver>();
+    return pushBehavior.push<bool>(
+      this,
+      resolver.resolve(requestedRedirect: returnTo),
+    );
   }
-}
-
-/// Resolves where signin sends the user, defaulting to the template demo
-/// dashboard when the caller has no explicit [returnTo].
-String _signInDestination(String? returnTo) {
-  return returnTo ?? DevModeDashboardScreen.routeName;
 }

--- a/apps/main/lib/presentation/modules/auth/signin/sign_in_redirect_resolver.dart
+++ b/apps/main/lib/presentation/modules/auth/signin/sign_in_redirect_resolver.dart
@@ -1,0 +1,45 @@
+import 'package:core/core.dart';
+import 'package:injectable/injectable.dart';
+
+import 'signin_route_args.dart';
+
+/// Resolves where the sign-in flow sends a user once they are authenticated.
+///
+/// Owns the two decisions the template previously duplicated across the router
+/// redirect and [AuthenticationCoordinator]: the default home route, and the
+/// validation of a requested `?redirect=` target (reject off-site URLs and
+/// loop-backs to sign-in). Both callers delegate here, so the landing policy
+/// has a single source of truth.
+///
+/// The template binds [DefaultSignInRedirectResolver], which lands on the
+/// dev-mode dashboard demo. A downstream app rebinds this contract in its
+/// `AppModule` to point at its own home route — and may override [resolve] to
+/// tighten or relax the redirect policy (e.g. role-based landing).
+abstract class SignInRedirectResolver {
+  /// Returns a safe in-app destination: [requestedRedirect] when it is a
+  /// same-origin path, otherwise the app's home route.
+  String resolve({String? requestedRedirect});
+}
+
+@LazySingleton(as: SignInRedirectResolver)
+class DefaultSignInRedirectResolver implements SignInRedirectResolver {
+  /// Where authenticated users land when no explicit redirect is requested.
+  String get home => DevModeDashboardScreen.routeName;
+
+  @override
+  String resolve({String? requestedRedirect}) {
+    if (requestedRedirect == null) {
+      return home;
+    }
+
+    final redirectUri = Uri.tryParse(requestedRedirect);
+    if (redirectUri == null ||
+        redirectUri.hasScheme ||
+        redirectUri.hasAuthority ||
+        !redirectUri.path.startsWith('/') ||
+        redirectUri.path == signInRouteName) {
+      return home;
+    }
+    return requestedRedirect;
+  }
+}

--- a/apps/main/lib/presentation/route/route.dart
+++ b/apps/main/lib/presentation/route/route.dart
@@ -3,6 +3,8 @@ import 'package:core/core.dart';
 
 import '../../di/di.dart';
 import '../modules/auth/authentication_coordinator.dart';
+import '../modules/auth/signin/sign_in_redirect_resolver.dart';
+import '../modules/auth/signin/signin_route_args.dart';
 import '../modules/auth/signin/views/signin_screen.dart';
 import '../modules/page_not_found/page_note_found.dart';
 import 'auth_gate_route_interceptor.dart';
@@ -10,6 +12,7 @@ import 'route_providers.config.dart';
 
 GoRouter buildAppRouter(AppGlobalBloc appBloc) {
   final localDataManager = injector<CoreLocalDataManager>();
+  final redirectResolver = injector<SignInRedirectResolver>();
 
   return buildFlGoRouter(
     routeProviders: buildAppRouteProviders(),
@@ -20,7 +23,12 @@ GoRouter buildAppRouter(AppGlobalBloc appBloc) {
     navigatorKey: globalNavigatorKey,
     observers: [myNavigatorObserver],
     redirect: (_, state) {
-      return _resolveLocaleRedirect(appBloc, state.uri);
+      return _resolveLocaleRedirect(appBloc, state.uri) ??
+          _resolveAuthenticatedSignInRedirect(
+            localDataManager,
+            redirectResolver,
+            state.uri,
+          );
     },
     errorBuilder: (context, __) => NotFoundPage(
       onBackToWelcomePage: () {
@@ -31,6 +39,21 @@ GoRouter buildAppRouter(AppGlobalBloc appBloc) {
       },
     ),
   );
+}
+
+String? _resolveAuthenticatedSignInRedirect(
+  CoreLocalDataManager localDataManager,
+  SignInRedirectResolver redirectResolver,
+  Uri uri,
+) {
+  if (!localDataManager.isAuthenticated || uri.path != SignInScreen.routeName) {
+    return null;
+  }
+
+  final requestedRedirect = SigninRouteArgs.fromUrlParams(
+    uri.queryParameters,
+  ).redirectTo;
+  return redirectResolver.resolve(requestedRedirect: requestedRedirect);
 }
 
 String? _resolveLocaleRedirect(AppGlobalBloc appBloc, Uri uri) {

--- a/apps/main/test/presentation/modules/auth/signin/sign_in_redirect_resolver_test.dart
+++ b/apps/main/test/presentation/modules/auth/signin/sign_in_redirect_resolver_test.dart
@@ -1,0 +1,71 @@
+import 'package:core/core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_flutter_base/presentation/modules/auth/signin/sign_in_redirect_resolver.dart';
+import 'package:my_flutter_base/presentation/modules/auth/signin/signin_route_args.dart';
+
+/// These cases pin the redirect security boundary: the resolver must only ever
+/// hand back a same-origin in-app path, falling back to [home] for anything
+/// that could escape the app (off-site URLs) or loop the user back to sign-in.
+/// A regression here re-opens an open-redirect hole on web, so the intent —
+/// "why each input is rejected" — is encoded alongside the expectation.
+void main() {
+  late DefaultSignInRedirectResolver resolver;
+
+  setUp(() {
+    resolver = DefaultSignInRedirectResolver();
+  });
+
+  group('DefaultSignInRedirectResolver.resolve', () {
+    test('falls back to the home route when no redirect is requested', () {
+      expect(resolver.resolve(), resolver.home);
+      expect(resolver.resolve(requestedRedirect: null), resolver.home);
+    });
+
+    test('the template home route is the dev-mode dashboard demo', () {
+      expect(resolver.home, DevModeDashboardScreen.routeName);
+    });
+
+    test('returns a valid same-origin path unchanged, preserving query', () {
+      expect(resolver.resolve(requestedRedirect: '/orders/123'), '/orders/123');
+      expect(
+        resolver.resolve(requestedRedirect: '/orders?status=open'),
+        '/orders?status=open',
+      );
+    });
+
+    test('rejects loop-backs to the sign-in route', () {
+      expect(
+        resolver.resolve(requestedRedirect: signInRouteName),
+        resolver.home,
+      );
+    });
+
+    test('rejects off-site targets with a scheme or authority', () {
+      for (final hostile in <String>[
+        'https://evil.com',
+        'javascript:alert(1)',
+        'data:text/html,x',
+        '//evil.com', // protocol-relative
+        r'/\evil.com', // backslash that Dart normalizes to an authority
+        r'\\evil.com',
+      ]) {
+        expect(
+          resolver.resolve(requestedRedirect: hostile),
+          resolver.home,
+          reason: '"$hostile" must not be returned as a destination',
+        );
+      }
+    });
+
+    test('rejects relative or non-rooted paths', () {
+      for (final notRooted in <String>[
+        'evil.com',
+        'orders/123',
+        ' //evil.com', // leading space stops it parsing as an authority
+        '%2F%2Fevil.com', // encoded slashes are not a literal leading slash
+      ]) {
+        expect(resolver.resolve(requestedRedirect: notRooted), resolver.home);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Why

Logged-in users always landed on the sign-in screen at launch. `buildAppRouter` hardcodes `initialLocation: SignInScreen.routeName`, and the auth-gate interceptor only wraps *protected* routes (it excludes the auth route), so it never redirected an already-authenticated user away from `/signin`. The saved token is loaded before the app builds, so this was a routing gap, not a token-load issue.

## What

- **Top-level redirect for authenticated users on `/signin`** — sends them to their destination (or the home route), also covering explicit `/signin` deep links.
- **`SignInRedirectResolver`** — a new app-owned seam that owns the post-auth landing policy in one place: the default home route, plus validation of a requested `?redirect=` target (rejects off-site URLs and loop-backs to sign-in). The router redirect and `AuthenticationCoordinator` both delegate to it, which:
  - collapses the `DevModeDashboardScreen` default that was previously duplicated across three spots, and
  - applies the redirect validation consistently on the login-completion path (`completeSignIn`), which previously navigated to an unvalidated target.
- **Downstream override** — a real project rebinds `DefaultSignInRedirectResolver` in its `AppModule` (one binding, no template edits) to set its own home route, or `implements SignInRedirectResolver` to change the policy entirely.
- **Docs** — added the "Sign-in redirect resolver" vocabulary entry + relationship line to `CONTEXT.md`.
- **Test** — unit test pinning the redirect validation boundary (off-site, protocol-relative/backslash, loop-back, null, and valid-path-passthrough cases).

## How downstream changes its landing page

```dart
@LazySingleton(as: SignInRedirectResolver)
class AppSignInRedirectResolver extends DefaultSignInRedirectResolver {
  @override
  String get home => HomeScreen.routeName;
}
```

## Verification

- `dart analyze lib test` → no issues
- New resolver test + full `apps/main` suite → pass
- DI regenerated via `make gen_main`

## Known limitation (pre-existing, out of scope)

On native platforms the `?redirect=` target travels as a route-arguments object rather than a URL query (`SigninRouteArgs.adaptiveArguments`), so the router redirect path only observes it on web. Unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
