### PR TITLE
refactor: architecture deepening sweep (state dispatch, redirect resolver, generator templates)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,8 +300,8 @@ Rules:
 - Events are hand-written subclasses of one abstract `<Feature>Event`; do not use Freezed unions for events.
 - States are hand-written subclasses of one abstract `<Feature>State`; do not use `FeatureState.loading()` / `.loaded()` Freezed unions.
 - State subclasses share one Freezed `_StateData` class.
-- The abstract state exposes `copyWith<T extends FeatureState>({_StateData? data})` backed by a `_factories` map.
-- Every concrete state class must be registered in `_factories` in the same edit.
+- The abstract state exposes `copyWith<T extends FeatureState>({_StateData? data})` backed by a `_factories` map, resolved through the shared `resolveState` helper from `package:core/core.dart`.
+- Every concrete state class must be registered in `_factories` in the same edit. A missing registration throws a descriptive `StateError` naming the unregistered state (via `resolveState`), not an opaque null-check failure.
 - Use `package:core/core.dart` for BLoC exports instead of importing `flutter_bloc` directly.
 - Run the relevant generator after changing `_StateData`, events, states, or bloc annotations.
 
@@ -336,9 +336,12 @@ abstract class FeatureState {
 
   FeatureState(this.data);
 
-  T copyWith<T extends FeatureState>({_StateData? data}) {
-    return _factories[T == FeatureState ? runtimeType : T]!(data ?? this.data);
-  }
+  T copyWith<T extends FeatureState>({_StateData? data}) =>
+      resolveState<FeatureState, _StateData>(
+        _factories,
+        requested: T == FeatureState ? runtimeType : T,
+        data: data ?? this.data,
+      ) as T;
 
   Item? get detail => data.detail;
   List<Item> get items => data.items;
@@ -352,7 +355,7 @@ class FeatureLoaded extends FeatureState {
   FeatureLoaded({required _StateData data}) : super(data);
 }
 
-final _factories = <Type, Function(_StateData data)>{
+final _factories = <Type, FeatureState Function(_StateData)>{
   FeatureInitial: (data) => FeatureInitial(data: data),
   FeatureLoaded: (data) => FeatureLoaded(data: data),
 };

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,11 +337,11 @@ abstract class FeatureState {
   FeatureState(this.data);
 
   T copyWith<T extends FeatureState>({_StateData? data}) =>
-      resolveState<FeatureState, _StateData>(
+      resolveState<T, FeatureState, _StateData>(
         _factories,
-        requested: T == FeatureState ? runtimeType : T,
+        fallbackType: runtimeType,
         data: data ?? this.data,
-      ) as T;
+      );
 
   Item? get detail => data.detail;
   List<Item> get items => data.items;

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,7 +37,7 @@ The specific `RouteProviderInterceptor` adapter that protects routes by token pr
 _Avoid_: auth guard, auth middleware.
 
 **Sign-in redirect resolver** (`SignInRedirectResolver`):
-The app-owned seam that decides where the sign-in flow lands a user once authenticated — the default home route, plus validation of a requested `?redirect=` target (rejecting off-site URLs and loop-backs to sign-in). The router redirect and the **Coordinator** both delegate to it, so the landing policy has one source of truth. The template binds `DefaultSignInRedirectResolver` (lands on the dev-mode dashboard demo); a downstream app rebinds this contract in its `AppModule` to set its own home route.
+The app-owned seam that decides where the sign-in flow lands a user once authenticated. It is a template-method base: it exposes one overridable knob — `home`, the default landing route — and owns the `resolve` validation of a requested `?redirect=` target (rejecting off-site URLs and loop-backs to sign-in) as inherited, shared behaviour. The router redirect and the **Coordinator** both delegate to it, so the landing policy has one source of truth and the open-redirect protection cannot be dropped by accident. The template binds `DefaultSignInRedirectResolver` (lands on the dev-mode dashboard demo); a downstream app extends the base and overrides `home` to set its own landing route (inheriting the validation), and may override `resolve` for a different policy.
 _Avoid_: home route constant, post-login navigator, redirect guard.
 
 ### Data layer

--- a/apps/main/lib/presentation/modules/auth/signin/bloc/signin_state.dart
+++ b/apps/main/lib/presentation/modules/auth/signin/bloc/signin_state.dart
@@ -15,9 +15,13 @@ abstract class SigninState {
 
   SigninState(this.data);
 
-  T copyWith<T extends SigninState>({_StateData? data}) {
-    return _factories[T == SigninState ? runtimeType : T]!(data ?? this.data);
-  }
+  T copyWith<T extends SigninState>({_StateData? data}) =>
+      resolveState<SigninState, _StateData>(
+            _factories,
+            requested: T == SigninState ? runtimeType : T,
+            data: data ?? this.data,
+          )
+          as T;
 
   String get phone => data.phone;
   String get password => data.password;
@@ -35,7 +39,7 @@ class LoginFailed extends SigninState {
   LoginFailed({_StateData data = const _StateData()}) : super(data);
 }
 
-final _factories = <Type, Function(_StateData data)>{
+final _factories = <Type, SigninState Function(_StateData)>{
   SigninInitial: (data) => SigninInitial(data: data),
   LoginSuccess: (data) => LoginSuccess(data: data),
   LoginFailed: (data) => LoginFailed(data: data),

--- a/apps/main/lib/presentation/modules/auth/signin/bloc/signin_state.dart
+++ b/apps/main/lib/presentation/modules/auth/signin/bloc/signin_state.dart
@@ -16,12 +16,11 @@ abstract class SigninState {
   SigninState(this.data);
 
   T copyWith<T extends SigninState>({_StateData? data}) =>
-      resolveState<SigninState, _StateData>(
-            _factories,
-            requested: T == SigninState ? runtimeType : T,
-            data: data ?? this.data,
-          )
-          as T;
+      resolveState<T, SigninState, _StateData>(
+        _factories,
+        fallbackType: runtimeType,
+        data: data ?? this.data,
+      );
 
   String get phone => data.phone;
   String get password => data.password;

--- a/apps/main/lib/presentation/modules/auth/signin/sign_in_redirect_resolver.dart
+++ b/apps/main/lib/presentation/modules/auth/signin/sign_in_redirect_resolver.dart
@@ -12,21 +12,24 @@ import 'signin_route_args.dart';
 /// has a single source of truth.
 ///
 /// The template binds [DefaultSignInRedirectResolver], which lands on the
-/// dev-mode dashboard demo. A downstream app rebinds this contract in its
-/// `AppModule` to point at its own home route — and may override [resolve] to
-/// tighten or relax the redirect policy (e.g. role-based landing).
+/// dev-mode dashboard demo. A downstream app customises the landing route by
+/// extending this base and overriding [home] — the redirect validation in
+/// [resolve] is inherited, so the open-redirect protection cannot be dropped by
+/// accident. Apps that need a different policy (e.g. role-based landing) may
+/// also override [resolve], then rebind the contract in their `AppModule`.
 abstract class SignInRedirectResolver {
-  /// Returns a safe in-app destination: [requestedRedirect] when it is a
-  /// same-origin path, otherwise the app's home route.
-  String resolve({String? requestedRedirect});
-}
-
-@LazySingleton(as: SignInRedirectResolver)
-class DefaultSignInRedirectResolver implements SignInRedirectResolver {
   /// Where authenticated users land when no explicit redirect is requested.
-  String get home => DevModeDashboardScreen.routeName;
+  ///
+  /// This is the one knob most apps override.
+  String get home;
 
-  @override
+  /// Returns a safe in-app destination: [requestedRedirect] when it is a
+  /// same-origin path, otherwise [home].
+  ///
+  /// The validation lives here, shared by every subclass: anything that could
+  /// escape the app (a scheme, an authority, a non-rooted path) or loop the
+  /// user back to sign-in falls back to [home]. This is a security boundary —
+  /// override it only to tighten or specialise the policy.
   String resolve({String? requestedRedirect}) {
     if (requestedRedirect == null) {
       return home;
@@ -42,4 +45,10 @@ class DefaultSignInRedirectResolver implements SignInRedirectResolver {
     }
     return requestedRedirect;
   }
+}
+
+@LazySingleton(as: SignInRedirectResolver)
+class DefaultSignInRedirectResolver extends SignInRedirectResolver {
+  @override
+  String get home => DevModeDashboardScreen.routeName;
 }

--- a/apps/main/test/presentation/modules/auth/signin/sign_in_redirect_resolver_test.dart
+++ b/apps/main/test/presentation/modules/auth/signin/sign_in_redirect_resolver_test.dart
@@ -8,6 +8,14 @@ import 'package:my_flutter_base/presentation/modules/auth/signin/signin_route_ar
 /// that could escape the app (off-site URLs) or loop the user back to sign-in.
 /// A regression here re-opens an open-redirect hole on web, so the intent —
 /// "why each input is rejected" — is encoded alongside the expectation.
+/// A downstream-style resolver that customises only the landing route. It must
+/// inherit the redirect validation from the base — overriding [home] alone must
+/// not re-open the open-redirect hole.
+class _CustomHomeResolver extends SignInRedirectResolver {
+  @override
+  String get home => '/dashboard';
+}
+
 void main() {
   late DefaultSignInRedirectResolver resolver;
 
@@ -66,6 +74,26 @@ void main() {
       ]) {
         expect(resolver.resolve(requestedRedirect: notRooted), resolver.home);
       }
+    });
+  });
+
+  group('SignInRedirectResolver subclass overriding only home', () {
+    late _CustomHomeResolver custom;
+
+    setUp(() {
+      custom = _CustomHomeResolver();
+    });
+
+    test('routes valid same-origin paths through unchanged', () {
+      expect(custom.resolve(requestedRedirect: '/orders/123'), '/orders/123');
+    });
+
+    test('inherits the validation: off-site targets fall back to its home', () {
+      expect(
+        custom.resolve(requestedRedirect: 'https://evil.com'),
+        '/dashboard',
+      );
+      expect(custom.resolve(), '/dashboard');
     });
   });
 }

--- a/core/lib/presentation/base/base.dart
+++ b/core/lib/presentation/base/base.dart
@@ -1,4 +1,5 @@
 export 'bloc/bloc_base.dart';
+export 'bloc/state_factory.dart';
 export 'delegate.dart';
 export 'state_base/mixin.dart';
 export 'state_base/state_base.dart';

--- a/core/lib/presentation/base/bloc/state_factory.dart
+++ b/core/lib/presentation/base/bloc/state_factory.dart
@@ -2,20 +2,23 @@
 ///
 /// Feature states keep a file-private `_factories` map pairing each concrete
 /// state subtype with a constructor that takes the shared `_StateData`. This
-/// helper centralises the lookup so the dispatch policy — and, crucially, its
-/// failure mode — lives in one place instead of being copy-pasted into every
-/// state file.
+/// helper owns the whole dispatch policy so it lives in one place instead of
+/// being copy-pasted into every state file: pick [TResult] when the caller
+/// requested a specific subtype, otherwise fall back to [fallbackType] (the
+/// caller's runtime type), look it up, and return it already narrowed to
+/// [TResult] — no `as` cast at the call site.
 ///
-/// Throws a descriptive [StateError] naming [requested] when the subtype was
+/// Throws a descriptive [StateError] naming the unresolved type when it was
 /// never registered, replacing the opaque "Null check operator used on a null
 /// value" the bare `_factories[type]!` lookup would otherwise raise far from
 /// the cause. The message points at the fix: register the state in the same
 /// edit that introduces it.
-TState resolveState<TState, TData>(
+TResult resolveState<TResult extends TState, TState, TData>(
   Map<Type, TState Function(TData)> factories, {
-  required Type requested,
+  required Type fallbackType,
   required TData data,
 }) {
+  final requested = TResult == TState ? fallbackType : TResult;
   final make = factories[requested];
   if (make == null) {
     throw StateError(
@@ -23,5 +26,5 @@ TState resolveState<TState, TData>(
       'Add it in the same edit as the state subclass.',
     );
   }
-  return make(data);
+  return make(data) as TResult;
 }

--- a/core/lib/presentation/base/bloc/state_factory.dart
+++ b/core/lib/presentation/base/bloc/state_factory.dart
@@ -1,0 +1,27 @@
+/// Resolves a concrete state instance from a feature's `_factories` registry.
+///
+/// Feature states keep a file-private `_factories` map pairing each concrete
+/// state subtype with a constructor that takes the shared `_StateData`. This
+/// helper centralises the lookup so the dispatch policy — and, crucially, its
+/// failure mode — lives in one place instead of being copy-pasted into every
+/// state file.
+///
+/// Throws a descriptive [StateError] naming [requested] when the subtype was
+/// never registered, replacing the opaque "Null check operator used on a null
+/// value" the bare `_factories[type]!` lookup would otherwise raise far from
+/// the cause. The message points at the fix: register the state in the same
+/// edit that introduces it.
+TState resolveState<TState, TData>(
+  Map<Type, TState Function(TData)> factories, {
+  required Type requested,
+  required TData data,
+}) {
+  final make = factories[requested];
+  if (make == null) {
+    throw StateError(
+      'State $requested is not registered in _factories. '
+      'Add it in the same edit as the state subclass.',
+    );
+  }
+  return make(data);
+}

--- a/core/test/presentation/base/bloc/state_factory_test.dart
+++ b/core/test/presentation/base/bloc/state_factory_test.dart
@@ -1,0 +1,59 @@
+import 'package:core/core.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Data {
+  const _Data(this.value);
+
+  final int value;
+}
+
+abstract class _State {
+  const _State(this.data);
+
+  final _Data data;
+}
+
+class _Initial extends _State {
+  const _Initial(super.data);
+}
+
+class _Loaded extends _State {
+  const _Loaded(super.data);
+}
+
+void main() {
+  final factories = <Type, _State Function(_Data)>{
+    _Initial: _Initial.new,
+    _Loaded: _Loaded.new,
+  };
+
+  group('resolveState', () {
+    test('builds the registered state for the requested type', () {
+      final state = resolveState<_State, _Data>(
+        factories,
+        requested: _Loaded,
+        data: const _Data(7),
+      );
+
+      expect(state, isA<_Loaded>());
+      expect(state.data.value, 7);
+    });
+
+    test('throws a descriptive StateError when the type is unregistered', () {
+      expect(
+        () => resolveState<_State, _Data>(
+          factories,
+          requested: _State,
+          data: const _Data(0),
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            allOf(contains('_State'), contains('_factories')),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/core/test/presentation/base/bloc/state_factory_test.dart
+++ b/core/test/presentation/base/bloc/state_factory_test.dart
@@ -21,6 +21,11 @@ class _Loaded extends _State {
   const _Loaded(super.data);
 }
 
+/// A subtype deliberately left out of [factories] to exercise the failure path.
+class _Errored extends _State {
+  const _Errored(super.data);
+}
+
 void main() {
   final factories = <Type, _State Function(_Data)>{
     _Initial: _Initial.new,
@@ -28,10 +33,10 @@ void main() {
   };
 
   group('resolveState', () {
-    test('builds the registered state for the requested type', () {
-      final state = resolveState<_State, _Data>(
+    test('builds the state for the requested subtype, ignoring fallback', () {
+      final state = resolveState<_Loaded, _State, _Data>(
         factories,
-        requested: _Loaded,
+        fallbackType: _Initial,
         data: const _Data(7),
       );
 
@@ -39,18 +44,29 @@ void main() {
       expect(state.data.value, 7);
     });
 
+    test('falls back to fallbackType when the request is the base type', () {
+      final state = resolveState<_State, _State, _Data>(
+        factories,
+        fallbackType: _Loaded,
+        data: const _Data(5),
+      );
+
+      expect(state, isA<_Loaded>());
+      expect(state.data.value, 5);
+    });
+
     test('throws a descriptive StateError when the type is unregistered', () {
       expect(
-        () => resolveState<_State, _Data>(
+        () => resolveState<_Errored, _State, _Data>(
           factories,
-          requested: _State,
+          fallbackType: _Initial,
           data: const _Data(0),
         ),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
             'message',
-            allOf(contains('_State'), contains('_factories')),
+            allOf(contains('_Errored'), contains('_factories')),
           ),
         ),
       );

--- a/tools/module_generator/lib/res/templates/common_module/bloc/state.dart
+++ b/tools/module_generator/lib/res/templates/common_module/bloc/state.dart
@@ -17,11 +17,11 @@ abstract class ${classNameKey}State {
   T copyWith<T extends ${classNameKey}State>({
     _StateData? data,
   }) =>
-      resolveState<${classNameKey}State, _StateData>(
+      resolveState<T, ${classNameKey}State, _StateData>(
         _factories,
-        requested: T == ${classNameKey}State ? runtimeType : T,
+        fallbackType: runtimeType,
         data: data ?? this.data,
-      ) as T;
+      );
 }
 
 class ${classNameKey}Initial extends ${classNameKey}State {

--- a/tools/module_generator/lib/res/templates/common_module/bloc/state.dart
+++ b/tools/module_generator/lib/res/templates/common_module/bloc/state.dart
@@ -16,11 +16,12 @@ abstract class ${classNameKey}State {
 
   T copyWith<T extends ${classNameKey}State>({
     _StateData? data,
-  }) {
-    return _factories[T == ${classNameKey}State ? runtimeType : T]!(
-      data ?? this.data,
-    );
-  }
+  }) =>
+      resolveState<${classNameKey}State, _StateData>(
+        _factories,
+        requested: T == ${classNameKey}State ? runtimeType : T,
+        data: data ?? this.data,
+      ) as T;
 }
 
 class ${classNameKey}Initial extends ${classNameKey}State {
@@ -29,11 +30,7 @@ class ${classNameKey}Initial extends ${classNameKey}State {
   }) : super(data);
 }
 
-final _factories = <
-    Type,
-    Function(
-  _StateData data,
-)>{
+final _factories = <Type, ${classNameKey}State Function(_StateData)>{
   ${classNameKey}Initial: (data) => ${classNameKey}Initial(
         data: data,
       ),

--- a/tools/module_generator/lib/res/templates/detail_module/bloc/state.dart
+++ b/tools/module_generator/lib/res/templates/detail_module/bloc/state.dart
@@ -19,11 +19,12 @@ abstract class ${classNameKey}State {
 
   T copyWith<T extends ${classNameKey}State>({
     _StateData? data,
-  }) {
-    return _factories[T == ${classNameKey}State ? runtimeType : T]!(
-      data ?? this.data,
-    );
-  }
+  }) =>
+      resolveState<${classNameKey}State, _StateData>(
+        _factories,
+        requested: T == ${classNameKey}State ? runtimeType : T,
+        data: data ?? this.data,
+      ) as T;
 
   $modelNameKey? get detail => data.detail;
 }
@@ -34,11 +35,7 @@ class ${classNameKey}Initial extends ${classNameKey}State {
   }) : super(data);
 }
 
-final _factories = <
-    Type,
-    Function(
-  _StateData data,
-)>{
+final _factories = <Type, ${classNameKey}State Function(_StateData)>{
   ${classNameKey}Initial: (data) => ${classNameKey}Initial(
         data: data,
       ),

--- a/tools/module_generator/lib/res/templates/detail_module/bloc/state.dart
+++ b/tools/module_generator/lib/res/templates/detail_module/bloc/state.dart
@@ -20,11 +20,11 @@ abstract class ${classNameKey}State {
   T copyWith<T extends ${classNameKey}State>({
     _StateData? data,
   }) =>
-      resolveState<${classNameKey}State, _StateData>(
+      resolveState<T, ${classNameKey}State, _StateData>(
         _factories,
-        requested: T == ${classNameKey}State ? runtimeType : T,
+        fallbackType: runtimeType,
         data: data ?? this.data,
-      ) as T;
+      );
 
   $modelNameKey? get detail => data.detail;
 }

--- a/tools/module_generator/lib/res/templates/listing_module/bloc/state.dart
+++ b/tools/module_generator/lib/res/templates/listing_module/bloc/state.dart
@@ -19,11 +19,12 @@ abstract class ${classNameKey}State {
 
   T copyWith<T extends ${classNameKey}State>({
     _StateData? data,
-  }) {
-    return _factories[T == ${classNameKey}State ? runtimeType : T]!(
-      data ?? this.data,
-    );
-  }
+  }) =>
+      resolveState<${classNameKey}State, _StateData>(
+        _factories,
+        requested: T == ${classNameKey}State ? runtimeType : T,
+        data: data ?? this.data,
+      ) as T;
 
   List<$modelNameKey> get items => data.items;
   bool get canLoadMore => data.canLoadMore;
@@ -35,11 +36,7 @@ class ${classNameKey}Initial extends ${classNameKey}State {
   }) : super(data);
 }
 
-final _factories = <
-    Type,
-    Function(
-  _StateData data,
-)>{
+final _factories = <Type, ${classNameKey}State Function(_StateData)>{
   ${classNameKey}Initial: (data) => ${classNameKey}Initial(
         data: data,
       ),

--- a/tools/module_generator/lib/res/templates/listing_module/bloc/state.dart
+++ b/tools/module_generator/lib/res/templates/listing_module/bloc/state.dart
@@ -20,11 +20,11 @@ abstract class ${classNameKey}State {
   T copyWith<T extends ${classNameKey}State>({
     _StateData? data,
   }) =>
-      resolveState<${classNameKey}State, _StateData>(
+      resolveState<T, ${classNameKey}State, _StateData>(
         _factories,
-        requested: T == ${classNameKey}State ? runtimeType : T,
+        fallbackType: runtimeType,
         data: data ?? this.data,
-      ) as T;
+      );
 
   List<$modelNameKey> get items => data.items;
   bool get canLoadMore => data.canLoadMore;

--- a/tools/module_generator/lib/res/templates/usecase/templates/listing_usecase.dart
+++ b/tools/module_generator/lib/res/templates/usecase/templates/listing_usecase.dart
@@ -4,8 +4,6 @@ import '../../../../common/definitions.dart';
 const listingUsecase =
     '''import 'dart:async';
 
-import 'package:injectable/injectable.dart';
-
 import 'package:core/domain/use_case/listing_use_case.dart';
 import 'package:data_source/data_source.dart';
 import 'package:injectable/injectable.dart';
@@ -40,12 +38,12 @@ class ${classNameKey}UsecaseImpl extends ${classNameKey}Usecase {
 
   late final _listingUsecase =
       ListingUseCase<$modelNameKey, ${modelNameKey}Filter>(
-    (offset, limit, page, [filter]) => _repository.getActivities(
-      /// TODO: Integrate with your filter and pagination
-      /// Example:
-      /// 'filters': filter?.filter,
-      /// 'limit': limit,
-      /// 'page': page,
+    (offset, limit, page, [filter]) => _repository.fetch${modelNameKey}s(
+      // TODO: call your repository method, passing filter + pagination.
+      // Example:
+      //   filters: filter?.filter,
+      //   limit: limit,
+      //   page: page,
     ).then(
       (value) => [...?value.data],
     ),


### PR DESCRIPTION
## Summary

An architecture-deepening pass over the template, turning shallow/duplicated seams into deep ones. Three deepening changes plus a code-review follow-up. Each change is a separate, independently-verified commit.

| Commit | Change |
|--------|--------|
| `7a843da` | Extract `resolveState` helper for BLoC state `_factories` dispatch |
| `f6c6842` | Make `SignInRedirectResolver` a template-method base |
| `0389a59` | Fix listing usecase generator template defects |
| `a903146` | Fold the full dispatch policy into `resolveState` (review fixup) |

## What changed

### BLoC state factory dispatch (`resolveState`)
The `_factories[T]!` lookup copy-pasted into every feature state file failed with an opaque *"Null check operator used on a null value"* when a concrete state subclass was added but not registered — far from the cause, with the invariant living only in convention.

- One pure helper in `core` now owns the lookup **and** the `T == Base ? runtimeType : T` dispatch policy, returning the result already narrowed (no `as T` at call sites).
- A missing registration throws a descriptive `StateError` naming the unregistered type.
- Unit-testable in isolation (new `core` test) instead of requiring a full feature BLoC.
- Migrated the signin state, all three module-generator templates, and the AGENTS.md reference shape. The hand-written `_StateData`/`_factories`/`copyWith<T>` convention is unchanged — only the dispatch line is shared.

### Sign-in redirect resolver (template-method base)
The resolver conflated two decisions behind one method (default home route + open-redirect validation). A downstream app that implemented the interface to change its home route would silently re-implement — and could drop — the security-critical validation.

- `SignInRedirectResolver` is now an abstract base that owns `resolve()` (the validation) and declares `home` as the one overridable knob.
- Downstream apps override `home` and inherit the open-redirect protection automatically; they may still override `resolve()` for a different policy.
- New test proves a `home`-only subclass still rejects off-site targets. DI binding unchanged.

### Listing usecase generator template
Fixed a duplicate `package:injectable` import and a misleading placeholder (`getActivities` + `///` doc-comments inside an argument list) that propagated into every generated listing module.

## Verification

- `core`: 3/3 tests pass; analyzer clean.
- `apps/main`: 11/11 tests pass (real `SigninBloc.copyWith` path + redirect resolver security cases); analyzer clean.
- Generator template package analyzes clean.

## Notes

A few originally-considered candidates were **deliberately not changed** after close reading: shallow-looking coordinators (they bundle typed `*Args` / centralize WebView security defaults), the empty `AppModule` (a conventional Injectable scaffold), and the `CoreDelegate` loading/error routing (a deliberate design that keeps BLoCs `BuildContext`-free and testable — ADR-worthy, not a sweep refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)