### PR TITLE
chore: align .run configs with .vscode/launch.json

### DIFF
--- a/.run/Dev Debug - Web.run.xml
+++ b/.run/Dev Debug - Web.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Dev Debug - Web" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--web-port 3000" />
+    <option name="filePath" value="$PROJECT_DIR$/apps/main/lib/main_dev.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Dev Debug.run.xml
+++ b/.run/Dev Debug.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Dev Debug" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="buildFlavor" value="dev" />
+    <option name="filePath" value="$PROJECT_DIR$/apps/main/lib/main_dev.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Dev Release.run.xml
+++ b/.run/Dev Release.run.xml
@@ -1,5 +1,6 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Main Dev" type="FlutterRunConfigurationType" factoryName="Flutter">
+  <configuration default="false" name="Dev Release" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--release" />
     <option name="buildFlavor" value="dev" />
     <option name="filePath" value="$PROJECT_DIR$/apps/main/lib/main_dev.dart" />
     <method v="2" />

--- a/.run/Production Debug.run.xml
+++ b/.run/Production Debug.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Production Debug" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="buildFlavor" value="prod" />
+    <option name="filePath" value="$PROJECT_DIR$/apps/main/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Production Release.run.xml
+++ b/.run/Production Release.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Production Release" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--release" />
+    <option name="buildFlavor" value="prod" />
+    <option name="filePath" value="$PROJECT_DIR$/apps/main/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Staging Debug.run.xml
+++ b/.run/Staging Debug.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Staging Debug" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="buildFlavor" value="staging" />
+    <option name="filePath" value="$PROJECT_DIR$/apps/main/lib/main_staging.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Staging Release.run.xml
+++ b/.run/Staging Release.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Staging Release" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--release" />
+    <option name="buildFlavor" value="staging" />
+    <option name="filePath" value="$PROJECT_DIR$/apps/main/lib/main_staging.dart" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
## Summary

Aligns the JetBrains/IntelliJ run configurations in `.run/` with the 7 configurations defined in `.vscode/launch.json`, so both IDEs expose the same run list.

Previously `.run/` contained only a single `Main Dev` config while `.vscode/launch.json` defined 7. This adds the missing configs and renames `Main Dev` → `Dev Debug` to match the VS Code naming.

| Run config | Entry point | Flavor | Extra args |
|---|---|---|---|
| Dev Debug | `main_dev.dart` | dev | — |
| Dev Debug - Web | `main_dev.dart` | — | `--web-port 3000` |
| Dev Release | `main_dev.dart` | dev | `--release` |
| Staging Debug | `main_staging.dart` | staging | — |
| Staging Release | `main_staging.dart` | staging | `--release` |
| Production Debug | `main.dart` | prod | — |
| Production Release | `main.dart` | prod | `--release` |

## Notes
- `--flavor` maps to the `buildFlavor` option; `--release` and `--web-port` map to `additionalArgs`.
- Config names match `launch.json` exactly so the two IDEs present the same run list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)