### PR TITLE
chore: upgrade @upstash/context7-mcp from 2.3.0 to 3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@upstash/context7-mcp": "2.3.0",
+        "@upstash/context7-mcp": "^3.2.1",
         "flutter-skill": "0.9.34"
       }
     },
@@ -150,21 +150,31 @@
       }
     },
     "node_modules/@upstash/context7-mcp": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@upstash/context7-mcp/-/context7-mcp-2.3.0.tgz",
-      "integrity": "sha512-RhSCftWWlMEPDmIApAawszSlbM9GuFwA0vL6vjZPYtrGzHdD8OuV2Q/z6iHQvdFg0fgw1/S9437hFT37deqNQg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@upstash/context7-mcp/-/context7-mcp-3.2.1.tgz",
+      "integrity": "sha512-ZVh1OAeOd5C4ORvPKYUgZSIwm+ofmofLyXS8p2Vvm0WH29axgNwhcc7sCr3aMzNX7oPKL9zH+1lb17W+AeMKtQ==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@types/express": "^5.0.4",
-        "commander": "^14.0.0",
+        "@upstash/redis": "^1.38.0",
+        "commander": "^13.1.0",
         "express": "^5.1.0",
         "jose": "^6.1.3",
-        "undici": "^6.6.3",
-        "zod": "^4.3.4"
+        "undici": "^6.26.0",
+        "zod": "^4.4.3"
       },
       "bin": {
         "context7-mcp": "dist/index.js"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/accepts": {
@@ -276,12 +286,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/content-disposition": {
@@ -1221,10 +1231,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@upstash/context7-mcp": "2.3.0",
+    "@upstash/context7-mcp": "^3.2.1",
     "flutter-skill": "0.9.34"
   }
 }


### PR DESCRIPTION
Upgrades Context7 MCP server from v2.3.0 to v3.2.1.

**Changes:**
- `@upstash/context7-mcp`: 2.3.0 → ^3.2.1
- New dependency: `@upstash/redis` (session management)
- Updated transitive deps: `@modelcontextprotocol/sdk`, `undici`, `zod`

**Notes:**
- v3 is fail-open without Redis config — sessions just reset between connections.
- To enable persistent sessions, set `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` env vars.