### PR TITLE
fix: preserve query on sign-in redirect to prevent post-login 404

### DIFF
--- a/apps/main/lib/presentation/route/route.dart
+++ b/apps/main/lib/presentation/route/route.dart
@@ -71,10 +71,12 @@ String? _resolveLocaleRedirect(AppGlobalBloc appBloc, Uri uri) {
     appBloc.changeLocale(locale);
   }
 
-  final nextQueryParameters = Map<String, String>.from(queryParameters)
-    ..remove('hl')
-    ..remove('lang');
-  final nextUri = uri.replace(queryParameters: nextQueryParameters);
+  final nextUri = withQueryParameters(
+    uri,
+    (query) => query
+      ..remove('hl')
+      ..remove('lang'),
+  );
   final nextLocation = nextUri.toString();
 
   if (nextLocation == uri.toString()) {

--- a/plugins/fl_navigation/lib/src/navigation_utils.dart
+++ b/plugins/fl_navigation/lib/src/navigation_utils.dart
@@ -6,6 +6,38 @@ import 'package:go_router/go_router.dart';
 /// Controls how GoRouter interprets destination strings.
 enum GoRouterNavigationTarget { location, name }
 
+/// Rebuilds [uri] with [mutate] applied to its query parameters.
+///
+/// `Uri.replace(queryParameters: {})` keeps `hasQuery == true` for an
+/// explicit-but-empty map, which leaves a dangling `?` in `toString()`
+/// (e.g. `/orders?` instead of `/orders`) — only omitting `queryParameters`
+/// entirely drops the `?`. Route redirects that strip query params (locale,
+/// tracking params, etc.) should go through this helper instead of calling
+/// `Uri.replace` directly, so that mistake can't be reintroduced per call site.
+Uri withQueryParameters(
+  Uri uri,
+  Map<String, String> Function(Map<String, String> query) mutate,
+) {
+  final nextQueryParameters = mutate(
+    Map<String, String>.from(uri.queryParameters),
+  );
+  if (nextQueryParameters.isNotEmpty) {
+    return uri.replace(queryParameters: nextQueryParameters);
+  }
+  // Uri.replace can't clear a query outright (a `null` query/queryParameters
+  // means "keep the existing one"), so the empty case has to be rebuilt from
+  // scratch — but every other component must be copied across explicitly,
+  // or an absolute uri would silently lose its scheme/authority here.
+  return Uri(
+    scheme: uri.hasScheme ? uri.scheme : null,
+    userInfo: uri.hasAuthority && uri.userInfo.isNotEmpty ? uri.userInfo : null,
+    host: uri.hasAuthority ? uri.host : null,
+    port: uri.hasAuthority ? uri.port : null,
+    path: uri.path,
+    fragment: uri.hasFragment ? uri.fragment : null,
+  );
+}
+
 abstract class PushBehavior {
   const PushBehavior({
     this.rootNavigator = false,
@@ -24,14 +56,26 @@ abstract class PushBehavior {
   });
 
   Uri buildUri(String routeName, Object? arguments) {
-    return Uri(
-      path: routeName,
-      queryParameters: arguments?.let((it) {
-        if (it is Map<String, dynamic> && kIsWeb) {
-          return Map.from(it);
-        }
-        return null;
-      }),
+    // routeName may already be a full "path?query" location (e.g. a resolved
+    // sign-in redirect target), so parse it instead of forcing it into
+    // `path:`, which would percent-encode any embedded "?" into "%3F". Only
+    // do this for absolute (leading "/") route names: a bare name containing
+    // a colon before any slash (e.g. "settings:advanced") would otherwise be
+    // misparsed by Uri.tryParse as having a URI scheme.
+    final base = routeName.startsWith('/')
+        ? (Uri.tryParse(routeName) ?? Uri(path: routeName))
+        : Uri(path: routeName);
+    final extraQueryParameters = arguments?.let((it) {
+      if (it is Map<String, dynamic> && kIsWeb) {
+        return Map<String, dynamic>.from(it);
+      }
+      return null;
+    });
+    if (extraQueryParameters == null || extraQueryParameters.isEmpty) {
+      return base;
+    }
+    return base.replace(
+      queryParameters: {...base.queryParameters, ...extraQueryParameters},
     );
   }
 

--- a/plugins/fl_navigation/test/fl_navigation_test.dart
+++ b/plugins/fl_navigation/test/fl_navigation_test.dart
@@ -4,6 +4,51 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pedantic/pedantic.dart';
 
 void main() {
+  group('withQueryParameters', () {
+    test('drops the query entirely instead of leaving a dangling "?"', () {
+      final uri = withQueryParameters(
+        Uri.parse('/dev-mode-dashboard?hl=vi'),
+        (query) => query..remove('hl'),
+      );
+
+      expect(uri.toString(), '/dev-mode-dashboard');
+      expect(uri.hasQuery, isFalse);
+    });
+
+    test('keeps remaining query parameters when some are left', () {
+      final uri = withQueryParameters(
+        Uri.parse('/orders?hl=vi&status=open'),
+        (query) => query..remove('hl'),
+      );
+
+      expect(uri.toString(), '/orders?status=open');
+    });
+
+    test('preserves the fragment when the query becomes empty', () {
+      final uri = withQueryParameters(
+        Uri.parse('/orders?hl=vi#section'),
+        (query) => query..remove('hl'),
+      );
+
+      expect(uri.toString(), '/orders#section');
+    });
+
+    test(
+      'preserves scheme and authority of an absolute uri when the query '
+      'becomes empty',
+      () {
+        final uri = withQueryParameters(
+          Uri.parse('https://example.com/path?hl=vi'),
+          (query) => query..remove('hl'),
+        );
+
+        expect(uri.toString(), 'https://example.com/path');
+        expect(uri.scheme, 'https');
+        expect(uri.host, 'example.com');
+      },
+    );
+  });
+
   group('buildFlGoRouter', () {
     test('enables URL reflection for imperative APIs by default', () {
       final previous = GoRouter.optionURLReflectsImperativeAPIs;
@@ -309,6 +354,36 @@ void main() {
       expect(uri.toString(), '/signin');
     });
 
+    test(
+      'preserves an embedded query string instead of percent-encoding it',
+      () {
+        final uri = const PushNamedBehavior().buildUri(
+          '/dev-mode-dashboard?hl=vi',
+          null,
+        );
+
+        expect(uri.path, '/dev-mode-dashboard');
+        expect(uri.queryParameters, {'hl': 'vi'});
+        expect(uri.toString(), '/dev-mode-dashboard?hl=vi');
+      },
+    );
+
+    test(
+      'treats a bare route name as literal path content, not a URI scheme',
+      () {
+        final uri = const PushNamedBehavior().buildUri(
+          'settings:advanced',
+          null,
+        );
+
+        // A leading "/" is what makes routeName eligible for Uri.tryParse;
+        // without one, "settings:advanced" must not be misread as scheme
+        // "settings" with path "advanced".
+        expect(uri.hasScheme, isFalse);
+        expect(uri.toString(), contains('settings'));
+      },
+    );
+
     testWidgets('named push uses GoRouter named routes when requested', (
       tester,
     ) async {
@@ -355,6 +430,30 @@ void main() {
 
       expect(find.text('Target'), findsOneWidget);
     });
+
+    testWidgets(
+      'pushReplacement resolves a route name that already carries a query '
+      'string, instead of 404-ing on a percent-encoded "?"',
+      (tester) async {
+        late BuildContext currentContext;
+        final router = _buildTextRouter(
+          routes: const {'/start': 'Start', '/target': 'Target'},
+          onBuild: (context) => currentContext = context,
+        );
+
+        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+        unawaited(
+          const PushReplacementNamedBehavior().push<Object?>(
+            currentContext,
+            '/target?hl=vi',
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Target'), findsOneWidget);
+      },
+    );
 
     testWidgets('removeAll uses go semantics with GoRouter', (tester) async {
       late BuildContext currentContext;


### PR DESCRIPTION
## Summary
- Deep-linking to a protected route with a locale param (e.g. `/dev-mode-dashboard?hl=vi`) while unauthenticated redirected to a malformed `/signin?redirect=...` with a dangling `?` and no destination, causing a 404 after login.
- Root cause was two separate Dart `Uri` construction bugs: `Uri.replace(queryParameters: {})` leaves a dangling `?` for an explicit-but-empty map, and `PushBehavior.buildUri` treated any `routeName` as literal path content, percent-encoding an embedded `?` into `%3F` so the resolved location matched no route.
- Fixed via a shared `withQueryParameters` helper (used by `_resolveLocaleRedirect`) and a `Uri.tryParse`-based `buildUri`, so this applies uniformly on web and mobile.
- Hardened both: `withQueryParameters` now preserves scheme/authority when the query empties out instead of silently downgrading an absolute uri to a relative path, and `buildUri` only parses `routeName` as a full uri when it starts with `/`, so a bare route name containing a colon can't be misread as having a URI scheme.

## Test plan
- [x] `flutter test` in `plugins/fl_navigation` — 26/26 pass, including new regression tests for the trailing-`?`, embedded-query, scheme-preservation, and bare-name cases
- [x] `flutter test` in `apps/main` — 11/11 pass
- [x] `flutter analyze` clean in both packages
- [x] Verified the full redirect round-trip (`/dev-mode-dashboard?hl=vi` → signin → post-login) end-to-end at the `Uri` level with a throwaway `dart run` script

🤖 Generated with [Claude Code](https://claude.com/claude-code)