### PR TITLE
chore: modernize lints, clear 207 analyzer issues, add make check gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,10 +16,8 @@
 - [ ] Barrel exports regenerated if module/plugin files added or removed
 - [ ] Route provider registered or interceptor updated if new route added
 - [ ] `make pub_get` run if `pubspec.yaml` changed
-- [ ] `make format` applied
-- [ ] Analyzer passes for affected package(s), for example `make analyze PACKAGES="apps/main core"` or full `make analyze`
+- [ ] `make check` passes (analyzer + formatting + tests across all packages)
 - [ ] Tests added/updated for new behavior
-- [ ] Existing tests pass for affected package(s), for example `make test PACKAGES="apps/main core"` or full `make test`
 
 ## ⚠️ Caution items
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,29 @@
+name: Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.41.9
+          channel: stable
+          cache: true
+
+      - name: Run definition-of-done gate
+        run: make check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,16 +120,18 @@ When a direct Flutter/Dart command is needed, check `.fvm_cache` first. If it co
 Useful make targets:
 
 ```bash
+make check       # Definition of done: analyze + format_check + test (see Testing and Verification)
 make setup       # Clean + pub_get + lang + asset + gen_all
 make pub_get     # Dependencies across plugins, core, and main app
 make gen_all     # Code generation for core, data_source, and main app
 make gen_core    # Code generation for core only
 make gen_main    # Code generation for apps/main only
 make lang        # Regenerate all localization outputs
-make format      # dart format .
+make format      # Format hand-written Dart code
+make format_check # Verify formatting without rewriting files
 make test        # Run tests when available
 make coverage_main
-make analyze     # If present in this branch; otherwise use fvm flutter analyze directly
+make analyze     # Analyze every package, or scope with PACKAGES="apps/main core"
 make help        # Show available commands
 ```
 
@@ -448,7 +450,22 @@ Do not change package IDs, bundle IDs, signing paths, CI secrets, provisioning d
 
 ## Testing and Verification
 
-For code changes, prefer the narrowest useful verification first, then broader checks:
+### Definition of done
+
+**A code change is not complete until `make check` passes.** It runs `analyze` + `format_check` + `test` across every package and exits non-zero on any failure:
+
+```bash
+make check
+```
+
+This is a hard gate, not a suggestion. Do not report work as finished, and do not open a PR, while `make check` is red — either fix the findings or tell the user explicitly what is still failing and why.
+
+Two things worth knowing:
+
+- **Analyzer infos fail the gate.** `flutter analyze` exits non-zero on `info`-level lints, not just errors. Infos are the ones that quietly pile up, so they count.
+- **Never run `dart fix --apply` to clear them.** It ignores `formatter: trailing_commas: preserve` and collapses hand-written multiline layouts across every file it touches, which is not automatically recoverable. Fix lints by hand, or with a targeted script that edits only the flagged tokens.
+
+While iterating, run the narrowest useful check first and save `make check` for the end:
 
 ```bash
 make format
@@ -457,7 +474,10 @@ make gen_core      # If core generated inputs changed
 make gen_main      # If app generated inputs changed
 fvm flutter analyze    # From the relevant package if no make target is available
 fvm flutter test       # From the relevant package if tests exist
+make check             # Definition of done — must be green before you call it complete
 ```
+
+Scope it to a package while working: `make analyze PACKAGES="apps/main core"`.
 
 For UI changes, run the app and smoke-test the affected flow before reporting completion whenever possible. If you cannot run the UI in this environment, say so explicitly.
 
@@ -486,3 +506,4 @@ Version pin: the Dart dep and the npm CLI are both held at `0.9.34`. `0.9.35`+ a
 6. Use make targets for generation and localization.
 7. Keep technical identifier changes deliberate and consistent across Android, iOS, docs, and CI scripts.
 8. Do not add speculative abstractions, fallback logic, or comments unless they are needed for the current task.
+9. Run `make check` before reporting any code change as complete; never use `dart fix --apply` to get it green.

--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ Useful make targets:
 | `make build` | Interactive Android/iOS distribution wrapper |
 | `make run_web_dev` / `make run_web_staging` | Run web server on port 3000 for dev/staging |
 | `make build_web` | Interactive web build wrapper |
+| `make check` | Run the full definition-of-done gate: analyze + format check + tests |
 | `make analyze` | Run analyzer across all packages; scope with `PACKAGES="apps/main core"` |
 | `make test` | Run tests for packages with test files; scope with `PACKAGES="apps/main core"` |
 | `make coverage_main` | Generate coverage for `apps/main` |
-| `make format` | Run `dart format .` |
+| `make format` | Format hand-written Dart files, excluding generated outputs |
+| `make format_check` | Verify hand-written Dart formatting without rewriting files |
 | `make clean` / `make clean_force` | Clean project build outputs |
 
 ## Runtime and security notes

--- a/apps/main/analysis_options.yaml
+++ b/apps/main/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   language:
@@ -6,10 +6,15 @@ analyzer:
   errors:
     # allow having TODOs in the code
     todo: ignore
+    # BLoC state classes intentionally expose private `_StateData` types.
+    library_private_types_in_public_api: ignore
+    # `_x = x ?? default` shadow-guard locals are an intentional convention.
+    no_leading_underscores_for_local_identifiers: ignore
   exclude:
     # exclude files
     - .dart_tool/**
     - build/**
+    - lib/generated
     - lib/generated_plugin_registrant.dart
     - lib/di/di.config.dart
     - "**.g.dart"

--- a/apps/main/lib/presentation/app.dart
+++ b/apps/main/lib/presentation/app.dart
@@ -8,7 +8,7 @@ import 'route/route.dart';
 import 'theme/theme.dart';
 
 class MainApplication extends StatefulWidget {
-  const MainApplication({Key? key}) : super(key: key);
+  const MainApplication({super.key});
 
   @override
   _MyAppState createState() => _MyAppState();

--- a/apps/main/lib/presentation/common_widget/chip_selection.dart
+++ b/apps/main/lib/presentation/common_widget/chip_selection.dart
@@ -46,7 +46,7 @@ class ChipSelection<T> extends StatelessWidget {
     int? minimumItemsPerRow,
   }) => ChipSelection._(
     items: items,
-    selected: [if (selected != null) selected],
+    selected: [?selected],
     onSelectionChange: (items) => onSelectionChange?.call(items.firstOrNull),
     getChipLabel: getChipLabel,
     decoration: decoration,

--- a/apps/main/lib/presentation/common_widget/shake_widget.dart
+++ b/apps/main/lib/presentation/common_widget/shake_widget.dart
@@ -10,12 +10,12 @@ class ShakeWidget extends StatefulWidget {
   final bool automaticallyStart;
 
   const ShakeWidget({
-    Key? key,
+    super.key,
     required this.child,
     this.duration = const Duration(milliseconds: 250),
     this.vibration = true,
     this.automaticallyStart = false,
-  }) : super(key: key);
+  });
 
   @override
   ShakeWidgetState createState() => ShakeWidgetState();

--- a/apps/main/lib/presentation/route/route.dart
+++ b/apps/main/lib/presentation/route/route.dart
@@ -30,7 +30,7 @@ GoRouter buildAppRouter(AppGlobalBloc appBloc) {
             state.uri,
           );
     },
-    errorBuilder: (context, __) => NotFoundPage(
+    errorBuilder: (context, _) => NotFoundPage(
       onBackToWelcomePage: () {
         context.openSignIn(
           localDataManager: localDataManager,

--- a/apps/main/lib/presentation/theme/theme_dialog.dart
+++ b/apps/main/lib/presentation/theme/theme_dialog.dart
@@ -91,11 +91,11 @@ class AppThemeDialog extends ThemeDialog {
     Widget? icon,
     TextStyle? titleStyle,
   }) {
-    final dismissFunc = (bool result) {
+    void dismissFunc(bool result) {
       if (dismissWhenAction) {
         Navigator.of(context, rootNavigator: useRootNavigator).pop(result);
       }
-    };
+    }
 
     final theme = context.theme;
     return _buildDialogBox(
@@ -174,11 +174,11 @@ class AppThemeDialog extends ThemeDialog {
     bool? isRequiredReason,
     Widget? icon,
   }) {
-    final dismissFunc = () {
+    void dismissFunc() {
       if (dismissWhenAction) {
         Navigator.of(context, rootNavigator: useRootNavigator).pop();
       }
-    };
+    }
 
     final theme = context.theme;
     final _icReason = controller;
@@ -197,7 +197,7 @@ class AppThemeDialog extends ThemeDialog {
                 icon ?? const SizedBox.shrink(),
                 InputTitleWidget(title: message, required: false),
                 const SizedBox(height: 8),
-                if (additionalWidget != null) additionalWidget,
+                ?additionalWidget,
                 InputContainer(
                   controller: _icReason,
                   maxLines: 4,
@@ -257,11 +257,12 @@ class AppThemeDialog extends ThemeDialog {
     bool barrierDismissible = true,
     Widget? icon,
   }) {
-    final dismissFunc = () {
+    void dismissFunc() {
       if (dismissWhenAction) {
         Navigator.of(context, rootNavigator: useRootNavigator).pop();
       }
-    };
+    }
+
     final theme = context.theme;
     return PopScope(
       canPop: barrierDismissible,

--- a/apps/main/pubspec.lock
+++ b/apps/main/pubspec.lock
@@ -965,10 +965,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_svg
-      sha256: "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f"
+      sha256: cd57f7969b4679317c17af6fd16ee233c1e60a82ed209d8a475c54fd6fd6f845
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.2.0"
   flutter_svg_provider:
     dependency: transitive
     description:
@@ -2317,10 +2317,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d"
+      sha256: a4f059dc26fc8295b5921376600a194c4ec7d55e72f2fe4c7d2831e103d461e6
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.1.19"
   vector_graphics_codec:
     dependency: transitive
     description:

--- a/apps/main/pubspec.lock
+++ b/apps/main/pubspec.lock
@@ -852,6 +852,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -957,10 +965,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_svg
-      sha256: cd57f7969b4679317c17af6fd16ee233c1e60a82ed209d8a475c54fd6fd6f845
+      sha256: "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   flutter_svg_provider:
     dependency: transitive
     description:
@@ -1145,7 +1153,7 @@ packages:
     source: hosted
     version: "0.2.5"
   get_it:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: get_it
       sha256: d85128a5dae4ea777324730dc65edd9c9f43155c109d5cc0a69cab74139fbac1
@@ -1353,7 +1361,7 @@ packages:
     source: hosted
     version: "0.2.2"
   injectable:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: injectable
       sha256: "1b86fab6a98c11a97e5c718afb00e628d47d183c2a2256392e995a4c561141c1"
@@ -1485,6 +1493,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.6"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   logger:
     dependency: transitive
     description:
@@ -1700,14 +1716,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.9.2"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   permission_handler:
     dependency: "direct main"
     description:
@@ -2309,10 +2317,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: a4f059dc26fc8295b5921376600a194c4ec7d55e72f2fe4c7d2831e103d461e6
+      sha256: "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.19"
+    version: "1.2.2"
   vector_graphics_codec:
     dependency: transitive
     description:

--- a/apps/main/pubspec.yaml
+++ b/apps/main/pubspec.yaml
@@ -28,6 +28,10 @@ dependencies:
   fl_navigation:
     path: ../../plugins/fl_navigation
 
+  # DI (imported directly; previously resolved via core)
+  get_it: ^7.2.0
+  injectable: ^2.4.4
+
   mobile_scanner: ^7.0.0
   image: ^4.0.17
   path_provider: ^2.1.2
@@ -73,6 +77,7 @@ dev_dependencies:
     sdk: flutter
   test: ^1.24.3
   mockito: ^5.4.0
+  flutter_lints: ^6.0.0
 
   build_runner: ^2.0.4
   retrofit_generator: 10.2.3

--- a/core/analysis_options.yaml
+++ b/core/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   language:
@@ -6,6 +6,10 @@ analyzer:
   errors:
     # allow having TODOs in the code
     todo: ignore
+    # BLoC `_StateData` and `.action.dart` extensions intentionally expose private types.
+    library_private_types_in_public_api: ignore
+    # Intentional `_x = x ?? default` locals shadow-guard constructor fields of the same name.
+    no_leading_underscores_for_local_identifiers: ignore
   exclude:
     # exclude files
     - .dart_tool/**

--- a/core/lib/common/services/permission_service.dart
+++ b/core/lib/common/services/permission_service.dart
@@ -1,5 +1,6 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../../l10n/localization_ext.dart';
@@ -23,7 +24,9 @@ class PermissionService {
       status = await ps.request();
 
       if (status.isPermanentlyDenied && required) {
-        unawaited(_showPermissionWarningDialog(context));
+        if (context.mounted) {
+          unawaited(_showPermissionWarningDialog(context));
+        }
 
         return false;
       }
@@ -52,6 +55,9 @@ class PermissionService {
     var isGranted = await checkPermission(ps, context);
 
     if (!isGranted) {
+      if (!context.mounted) {
+        return isGranted;
+      }
       isGranted = await _requestPermission(ps, context, required: required);
     }
     return isGranted;

--- a/core/lib/core.dart
+++ b/core/lib/core.dart
@@ -1,4 +1,6 @@
-library core;
+library;
+
+export 'dart:async' show unawaited;
 
 export 'package:auto_size_text/auto_size_text.dart';
 export 'package:badges/badges.dart';
@@ -23,7 +25,6 @@ export 'package:flutter_widget_from_html/flutter_widget_from_html.dart'
 export 'package:fluttertoast/fluttertoast.dart';
 export 'package:logger/logger.dart';
 export 'package:mime/mime.dart';
-export 'package:pedantic/pedantic.dart';
 export 'package:rxdart/rxdart.dart';
 export 'package:shared_preferences/shared_preferences.dart';
 export 'package:sqflite/sqflite.dart';

--- a/core/lib/data/data_source/remote/interceptor/logger_interceptor.dart
+++ b/core/lib/data/data_source/remote/interceptor/logger_interceptor.dart
@@ -147,6 +147,7 @@ class LoggerInterceptor extends Interceptor {
 
   @override
   Future<void> onError(
+    // ignore: avoid_renaming_method_parameters
     DioException error,
     ErrorInterceptorHandler handler,
   ) async {

--- a/core/lib/presentation/base/bloc/bloc_base.dart
+++ b/core/lib/presentation/base/bloc/bloc_base.dart
@@ -3,7 +3,7 @@ import 'package:flutter/foundation.dart';
 import '../../../core.dart';
 
 abstract class CoreBlocBase<E, S> extends Bloc<E, S> with CoreDelegate {
-  CoreBlocBase(S s) : super(s);
+  CoreBlocBase(super.s);
 
   @override
   void onError(Object error, StackTrace stackTrace) {

--- a/core/lib/presentation/base/state_base/state_base.ext.dart
+++ b/core/lib/presentation/base/state_base/state_base.ext.dart
@@ -17,6 +17,9 @@ extension StateBaseExtention on CoreStateBase {
       Permission.location,
       context,
     );
+    if (!mounted) {
+      return granted;
+    }
 
     if (!granted) {
       final status = await PermissionService().requestPermission(
@@ -24,18 +27,26 @@ extension StateBaseExtention on CoreStateBase {
         context,
         required: required,
       );
+      if (!mounted) {
+        return status;
+      }
 
       if (status) {
         if (await Geolocator.isLocationServiceEnabled()) {
+          if (!mounted) {
+            return status;
+          }
           await context.read<LocationCubit>().refreshLocation().first;
           return true;
         } else if (required) {
-          unawaited(
-            showNoticeDialog(
-              context: context,
-              message: context.coreL10n.pleaseEnableGPS,
-            ),
-          );
+          if (mounted) {
+            unawaited(
+              showNoticeDialog(
+                context: context,
+                message: context.coreL10n.pleaseEnableGPS,
+              ),
+            );
+          }
           return false;
         }
       }

--- a/core/lib/presentation/common_widget/auto_complete_field/auto_complete_field.dart
+++ b/core/lib/presentation/common_widget/auto_complete_field/auto_complete_field.dart
@@ -41,7 +41,7 @@ class AutoCompleteField<T extends Object> extends StatefulWidget {
   final String? helperText;
 
   const AutoCompleteField({
-    Key? key,
+    super.key,
     required this.displayStringForOption,
     required this.onSelected,
     required this.fetch,
@@ -69,7 +69,7 @@ class AutoCompleteField<T extends Object> extends StatefulWidget {
     this.validation,
     this.warning,
     this.helperText,
-  }) : super(key: key);
+  });
 
   @override
   State<AutoCompleteField<T>> createState() => _AutoCompleteFieldState<T>();

--- a/core/lib/presentation/common_widget/box_title.dart
+++ b/core/lib/presentation/common_widget/box_title.dart
@@ -12,7 +12,7 @@ class BoxTitle extends StatelessWidget {
   final bool isRequired;
 
   const BoxTitle({
-    Key? key,
+    super.key,
     this.titleWidget,
     required this.child,
     this.title,
@@ -23,8 +23,7 @@ class BoxTitle extends StatelessWidget {
   }) : assert(
          title != null || titleWidget != null,
          'Please provide BoxTitle.title || BoxTitle.titleWidget',
-       ),
-       super(key: key);
+       );
 
   @override
   Widget build(BuildContext context) {

--- a/core/lib/presentation/common_widget/custom_bottom_navigation_bar.dart
+++ b/core/lib/presentation/common_widget/custom_bottom_navigation_bar.dart
@@ -29,12 +29,12 @@ class BottomBarItemData {
 
 class CustomBottomNavigationBar extends StatefulWidget {
   const CustomBottomNavigationBar({
-    Key? key,
+    super.key,
     this.onItemSelection,
     this.selectedIdx = 0,
     this.items,
     this.borderRadius,
-  }) : super(key: key);
+  });
 
   final Future<bool> Function(int)? onItemSelection;
   final int? selectedIdx;
@@ -159,12 +159,12 @@ class BottomItem extends StatelessWidget {
   final double iconSize;
 
   const BottomItem({
-    Key? key,
+    super.key,
     required this.item,
     this.onPressed,
     this.selected = false,
     this.iconSize = 24.0,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/core/lib/presentation/common_widget/custom_cupertino_date_picker.dart
+++ b/core/lib/presentation/common_widget/custom_cupertino_date_picker.dart
@@ -31,15 +31,15 @@ Future<dynamic> showCupertinoCustomDatePicker(
 }
 
 class CupertinoDatePickerCustom extends StatefulWidget {
-  CupertinoDatePickerCustom({
-    Key? key,
+  const CupertinoDatePickerCustom({
+    super.key,
     required this.initialDateTime,
     this.maxDate,
     this.minDate,
     this.mode = CupertinoDatePickerMode.date,
     this.onCancelled,
     this.onConfirmed,
-  }) : super(key: key);
+  });
 
   final DateTime? initialDateTime;
   final DateTime? maxDate;
@@ -79,12 +79,12 @@ class _CupertinoDatePickerCustomState extends State<CupertinoDatePickerCustom> {
           onTap: () {},
           child: SafeArea(
             top: false,
-            child: Container(
+            child: SizedBox(
               height: pickerSheetHeight + pickerButtonHeight,
               child: Column(
                 children: <Widget>[
                   _buildFunction(),
-                  Container(
+                  SizedBox(
                     height: pickerSheetHeight - 30,
                     child: CupertinoDatePicker(
                       backgroundColor: CupertinoColors.systemBackground

--- a/core/lib/presentation/common_widget/date_picker/calendar_date_picker.dart
+++ b/core/lib/presentation/common_widget/date_picker/calendar_date_picker.dart
@@ -16,7 +16,7 @@ class DateInputCalendarPicker extends StatefulWidget {
   final bool required;
 
   const DateInputCalendarPicker({
-    Key? key,
+    super.key,
     this.onTapInputField,
     required this.onDateSelected,
     this.initial,
@@ -28,7 +28,7 @@ class DateInputCalendarPicker extends StatefulWidget {
     this.maxDate,
     this.iconColor,
     this.required = false,
-  }) : super(key: key);
+  });
 
   @override
   State<DateInputCalendarPicker> createState() =>
@@ -70,6 +70,9 @@ class _DateInputCalendarPickerState extends State<DateInputCalendarPicker> {
       onTapHeader: () {
         widget.onTapInputField?.call();
         Future.delayed(const Duration(milliseconds: 500), () {
+          if (!context.mounted) {
+            return;
+          }
           Scrollable.ensureVisible(
             context,
             duration: const Duration(milliseconds: 250),
@@ -166,7 +169,7 @@ class WeekInputCalendarPicker extends StatefulWidget {
   final bool required;
 
   const WeekInputCalendarPicker({
-    Key? key,
+    super.key,
     this.onTapInputField,
     required this.onDateSelected,
     this.initial,
@@ -178,7 +181,7 @@ class WeekInputCalendarPicker extends StatefulWidget {
     this.maxDate,
     this.iconColor,
     this.required = false,
-  }) : super(key: key);
+  });
 
   @override
   State<WeekInputCalendarPicker> createState() =>
@@ -301,7 +304,7 @@ class _WeekInputCalendarPickerState extends State<WeekInputCalendarPicker> {
 
 class TableCalendarDatePicker extends StatelessWidget {
   const TableCalendarDatePicker({
-    Key? key,
+    super.key,
     required this.monthStr,
     required this.value,
     required this.onSelected,
@@ -310,7 +313,7 @@ class TableCalendarDatePicker extends StatelessWidget {
     this.rangeStart,
     this.rangeEnd,
     this.availableGestures = AvailableGestures.all,
-  }) : super(key: key);
+  });
 
   final String monthStr;
   final DateTime? value;

--- a/core/lib/presentation/common_widget/date_picker/cupertino_time_picker_custom.dart
+++ b/core/lib/presentation/common_widget/date_picker/cupertino_time_picker_custom.dart
@@ -24,12 +24,12 @@ Future<dynamic> showCupertinoCustomTimePicker(
 
 class CupertinoTimePickerCustom extends StatefulWidget {
   const CupertinoTimePickerCustom({
-    Key? key,
+    super.key,
     required this.initialTimerDuration,
     this.onCancelled,
     this.onComfirmed,
     required this.theme,
-  }) : super(key: key);
+  });
 
   final Duration? initialTimerDuration;
   final void Function()? onCancelled;

--- a/core/lib/presentation/common_widget/date_picker/custom_picker_model.dart
+++ b/core/lib/presentation/common_widget/date_picker/custom_picker_model.dart
@@ -12,8 +12,8 @@ class DateDDMMYYYModel extends CommonPickerModel {
     DateTime? currentTime,
     DateTime? maxTime,
     DateTime? minTime,
-    LocaleType? locale,
-  }) : super(locale: locale) {
+    super.locale,
+  }) {
     this.maxTime =
         maxTime ?? DateTime.now().add(const Duration(days: 365 * 100));
     this.minTime =
@@ -73,7 +73,7 @@ class DateDDMMYYYModel extends CommonPickerModel {
     final maxMonth = _maxMonthOfCurrentYear();
 
     middleList = List.generate(maxMonth - minMonth + 1, (int index) {
-      return '${_localeMonth(minMonth + index)}';
+      return _localeMonth(minMonth + index);
     });
   }
 
@@ -256,8 +256,8 @@ class DateMMYYYModel extends CommonPickerModel {
     DateTime? currentTime,
     DateTime? maxTime,
     DateTime? minTime,
-    LocaleType? locale,
-  }) : super(locale: locale) {
+    super.locale,
+  }) {
     this.maxTime = maxTime ?? DateTime(2099, 12, 31);
     this.minTime = minTime ?? DateTime(1900, 1, 1);
 
@@ -315,7 +315,7 @@ class DateMMYYYModel extends CommonPickerModel {
     final maxMonth = _maxMonthOfCurrentYear();
 
     middleList = List.generate(maxMonth - minMonth + 1, (int index) {
-      return '${_localeMonth(minMonth + index)}';
+      return _localeMonth(minMonth + index);
     });
   }
 
@@ -505,11 +505,11 @@ class MyTimePickerModel extends CommonPickerModel {
 
   MyTimePickerModel({
     DateTime? currentTime,
-    LocaleType? locale,
+    super.locale,
     this.showSecondsColumn = true,
     this.minTime,
     this.maxTime,
-  }) : super(locale: locale) {
+  }) {
     this.currentTime = currentTime ?? DateTime.now();
 
     final initialInSec = Duration(

--- a/core/lib/presentation/common_widget/date_picker/date_range_picker.dart
+++ b/core/lib/presentation/common_widget/date_picker/date_range_picker.dart
@@ -401,7 +401,7 @@ class DateRangePickerBuilder extends StatelessWidget {
       locale: context.appDateLocale,
     );
     return [
-      '${selected.key}',
+      selected.key,
       if (timeStr.isNotNullOrEmpty)
         [
           if (dateRange.from == null && dateRange.to != null)

--- a/core/lib/presentation/common_widget/date_picker/flutter_datetime_picker/flutter_datetime_picker.dart
+++ b/core/lib/presentation/common_widget/date_picker/flutter_datetime_picker/flutter_datetime_picker.dart
@@ -198,11 +198,10 @@ class _DatePickerRoute<T> extends PopupRoute<T> {
     CustomDatePickerTheme? datePickerTheme,
     this.barrierLabel,
     this.locale,
-    RouteSettings? settings,
+    super.settings,
     BasePickerModel? pickerModel,
   }) : pickerModel = pickerModel ?? DatePickerModel(),
-       datePickerTheme = datePickerTheme ?? CustomDatePickerTheme(),
-       super(settings: settings);
+       datePickerTheme = datePickerTheme ?? CustomDatePickerTheme();
 
   final bool? showTitleActions;
   final DateChangedCallback? onChanged;
@@ -257,12 +256,11 @@ class _DatePickerRoute<T> extends PopupRoute<T> {
 
 class _DatePickerComponent extends StatefulWidget {
   const _DatePickerComponent({
-    Key? key,
     required this.route,
     required this.pickerModel,
     this.onChanged,
     this.locale,
-  }) : super(key: key);
+  });
 
   final DateChangedCallback? onChanged;
 

--- a/core/lib/presentation/common_widget/date_picker/flutter_datetime_picker/src/date_model.dart
+++ b/core/lib/presentation/common_widget/date_picker/flutter_datetime_picker/src/date_model.dart
@@ -136,8 +136,8 @@ class DatePickerModel extends CommonPickerModel {
     DateTime? currentTime,
     DateTime? maxTime,
     DateTime? minTime,
-    LocaleType? locale,
-  }) : super(locale: locale) {
+    super.locale,
+  }) {
     this.maxTime = maxTime ?? DateTime(2049, 12, 31);
     this.minTime = minTime ?? DateTime(1970, 1, 1);
 
@@ -197,7 +197,7 @@ class DatePickerModel extends CommonPickerModel {
     final maxMonth = _maxMonthOfCurrentYear();
 
     middleList = List.generate(maxMonth - minMonth + 1, (int index) {
-      return '${_localeMonth(minMonth + index)}';
+      return _localeMonth(minMonth + index);
     });
   }
 
@@ -369,9 +369,9 @@ class TimePickerModel extends CommonPickerModel {
 
   TimePickerModel({
     DateTime? currentTime,
-    LocaleType? locale,
+    super.locale,
     this.showSecondsColumn = true,
-  }) : super(locale: locale) {
+  }) {
     this.currentTime = currentTime ?? DateTime.now();
 
     _currentLeftIndex = this.currentTime.hour;
@@ -453,8 +453,7 @@ class TimePickerModel extends CommonPickerModel {
 
 //a time picker model
 class Time12hPickerModel extends CommonPickerModel {
-  Time12hPickerModel({DateTime? currentTime, LocaleType? locale})
-    : super(locale: locale) {
+  Time12hPickerModel({DateTime? currentTime, super.locale}) {
     this.currentTime = currentTime ?? DateTime.now();
 
     _currentLeftIndex = this.currentTime.hour % 12;
@@ -542,8 +541,8 @@ class DateTimePickerModel extends CommonPickerModel {
     DateTime? currentTime,
     DateTime? maxTime,
     DateTime? minTime,
-    LocaleType? locale,
-  }) : super(locale: locale) {
+    super.locale,
+  }) {
     if (currentTime != null) {
       this.currentTime = currentTime;
       if (maxTime != null &&

--- a/core/lib/presentation/common_widget/dropdown/multiple/multiple_choice_dropdown_widget.dart
+++ b/core/lib/presentation/common_widget/dropdown/multiple/multiple_choice_dropdown_widget.dart
@@ -36,7 +36,8 @@ class MultipleChoiceDropdownWidget<T> extends StatefulWidget {
   final TextStyle? errorStyle;
   final BorderRadius? borderRadius;
 
-  MultipleChoiceDropdownWidget({
+  const MultipleChoiceDropdownWidget({
+    super.key,
     this.titleStyle,
     this.title,
     this.titleMode = TitleMode.above,

--- a/core/lib/presentation/common_widget/dropdown/single/dropdown_widget.dart
+++ b/core/lib/presentation/common_widget/dropdown/single/dropdown_widget.dart
@@ -33,7 +33,8 @@ class DropdownWidget<T> extends StatefulWidget {
   final BorderRadius? borderRadius;
   final VoidCallback? onTap;
 
-  DropdownWidget({
+  const DropdownWidget({
+    super.key,
     this.title,
     this.titleStyle,
     this.titleMode = TitleMode.above,

--- a/core/lib/presentation/common_widget/empty_data.dart
+++ b/core/lib/presentation/common_widget/empty_data.dart
@@ -10,12 +10,12 @@ class EmptyData extends StatelessWidget {
   final double? iconHeight;
 
   const EmptyData({
-    Key? key,
+    super.key,
     required this.message,
     this.icon,
     this.iconWidth = 200,
     this.iconHeight = 200,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/core/lib/presentation/common_widget/footer_widget.dart
+++ b/core/lib/presentation/common_widget/footer_widget.dart
@@ -6,13 +6,13 @@ import '../extentions/context_extention.dart';
 
 class FooterWidget extends StatelessWidget {
   const FooterWidget({
-    Key? key,
+    super.key,
     required this.child,
     this.alignment,
     this.paddingBottom,
     this.backgroundColor,
     this.shadowVisibility = true,
-  }) : super(key: key);
+  });
 
   final Widget child;
   final AlignmentGeometry? alignment;

--- a/core/lib/presentation/common_widget/forms/main_page_form.dart
+++ b/core/lib/presentation/common_widget/forms/main_page_form.dart
@@ -14,7 +14,7 @@ class MainPageForm extends StatelessWidget {
   /// The [floatingActionButtonLocation]
   /// defaults to [FloatingActionButtonLocation.miniEndDocked].
   const MainPageForm({
-    Key? key,
+    super.key,
     // Content
     this.body,
     this.title,
@@ -38,7 +38,7 @@ class MainPageForm extends StatelessWidget {
     this.hasBottomBorderRadius,
     this.titleMaxLines,
     this.titleStyle,
-  }) : super(key: key);
+  });
 
   /// Main content of the page.
   final Widget? body;

--- a/core/lib/presentation/common_widget/forms/screen_form.dart
+++ b/core/lib/presentation/common_widget/forms/screen_form.dart
@@ -10,7 +10,7 @@ import '../../../core.dart';
 
 class ScreenForm extends StatefulWidget {
   const ScreenForm({
-    Key? key,
+    super.key,
     // Appearance
     this.bgColor,
     this.appbarColor,
@@ -51,7 +51,7 @@ class ScreenForm extends StatefulWidget {
     this.bottomNavigationBar,
     this.endDrawer,
     this.drawer,
-  }) : super(key: key);
+  });
 
   /// Text to display as the screen title
   final String? title;

--- a/core/lib/presentation/common_widget/gender_selection.dart
+++ b/core/lib/presentation/common_widget/gender_selection.dart
@@ -14,13 +14,13 @@ class GenderSelection extends StatefulWidget {
   final TextStyle? titleStyle;
 
   const GenderSelection({
-    Key? key,
+    super.key,
     required this.title,
     this.titleStyle,
     this.onChange,
     this.defaultGender,
     this.required = false,
-  }) : super(key: key);
+  });
 
   @override
   State<GenderSelection> createState() => _MyWidgetState();

--- a/core/lib/presentation/common_widget/group_sliver/render/render_sliver_group.dart
+++ b/core/lib/presentation/common_widget/group_sliver/render/render_sliver_group.dart
@@ -225,9 +225,10 @@ class _RenderSliverGroup extends RenderSliver with RenderSliverHelpers {
       // paint child
       if (child != null && child!.geometry!.visible) {
         final childParentData = child!.parentData as SliverPhysicalParentData?;
-        final painter = (PaintingContext context, Offset offset) {
+        void painter(PaintingContext context, Offset offset) {
           context.paintChild(child!, offset);
-        };
+        }
+
         if (_clipRRect != null && _clipRRect != RRect.zero) {
           context.pushClipRRect(
             needsCompositing,

--- a/core/lib/presentation/common_widget/group_sliver/widget/sliver_group.dart
+++ b/core/lib/presentation/common_widget/group_sliver/widget/sliver_group.dart
@@ -4,13 +4,12 @@ part of '../group_sliver.dart';
 
 @immutable
 class _SliverGroup extends RenderObjectWidget {
-  _SliverGroup({
-    Key? key,
+  const _SliverGroup({
     this.margin,
     this.borderRadius,
     this.decorationWidget,
     this.sliver,
-  }) : super(key: key);
+  });
 
   final EdgeInsets? margin;
   final BorderRadius? borderRadius;
@@ -37,7 +36,7 @@ class _SliverGroup extends RenderObjectWidget {
 }
 
 class _SliverGroupElement extends RenderObjectElement {
-  _SliverGroupElement(_SliverGroup widget) : super(widget);
+  _SliverGroupElement(super.widget);
 
   Element? _decoration;
   Element? _sliver;

--- a/core/lib/presentation/common_widget/group_sliver/widget/sliver_group_builder.dart
+++ b/core/lib/presentation/common_widget/group_sliver/widget/sliver_group_builder.dart
@@ -2,6 +2,7 @@ part of '../group_sliver.dart';
 
 class SliverGroupBuilder extends StatelessWidget {
   const SliverGroupBuilder({
+    super.key,
     this.margin = EdgeInsets.zero,
     this.padding = EdgeInsets.zero,
     this.decoration,

--- a/core/lib/presentation/common_widget/image_view_wrapper.dart
+++ b/core/lib/presentation/common_widget/image_view_wrapper.dart
@@ -6,6 +6,7 @@ import '../../common/constants.dart';
 class ImageViewWrapper extends ImageView {
   ImageViewWrapper.avatar(
     String source, {
+    super.key,
     super.width,
     super.height,
     super.fit,
@@ -23,6 +24,7 @@ class ImageViewWrapper extends ImageView {
 
   ImageViewWrapper.item(
     String source, {
+    super.key,
     super.width,
     super.height,
     super.fit,
@@ -40,6 +42,7 @@ class ImageViewWrapper extends ImageView {
 
   ImageViewWrapper.banner(
     String source, {
+    super.key,
     super.width,
     super.height,
     super.fit,

--- a/core/lib/presentation/common_widget/inform_popup.dart
+++ b/core/lib/presentation/common_widget/inform_popup.dart
@@ -7,8 +7,11 @@ class InformationPopup extends StatelessWidget {
   final String content;
   final String title;
 
-  const InformationPopup({Key? key, required this.content, required this.title})
-    : super(key: key);
+  const InformationPopup({
+    super.key,
+    required this.content,
+    required this.title,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/core/lib/presentation/common_widget/input_container/input_container.dart
+++ b/core/lib/presentation/common_widget/input_container/input_container.dart
@@ -55,7 +55,7 @@ class InputContainer extends StatefulWidget {
   final Widget? iconClear;
 
   const InputContainer({
-    Key? key,
+    super.key,
     this.controller,
     this.hint,
     this.isPassword = false,
@@ -103,7 +103,7 @@ class InputContainer extends StatefulWidget {
     this.onFocusChanged,
     this.iconClear,
     this.selectAllWhenFocus = false,
-  }) : super(key: key);
+  });
 
   @override
   State<InputContainer> createState() => _InputContainerState();

--- a/core/lib/presentation/common_widget/input_container/text_tagging_controller.dart
+++ b/core/lib/presentation/common_widget/input_container/text_tagging_controller.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 /// Usage
 ///
 /// =========> INIT Controller
-/// final _textTaggingController = TextTaggingController<User>(
+/// final _textTaggingController = `TextTaggingController<User>`(
 ///   tagBuilder: (context, style, withComposing, user) {
 ///     return Container(
 ///       decoration: BoxDecoration(

--- a/core/lib/presentation/common_widget/load_failed.dart
+++ b/core/lib/presentation/common_widget/load_failed.dart
@@ -5,7 +5,7 @@ import '../extentions/extention.dart';
 class LoadFailed extends StatelessWidget {
   final void Function()? onTap;
 
-  const LoadFailed({Key? key, this.onTap}) : super(key: key);
+  const LoadFailed({super.key, this.onTap});
 
   @override
   Widget build(BuildContext context) {

--- a/core/lib/presentation/common_widget/loadding_button/loading_button.dart
+++ b/core/lib/presentation/common_widget/loadding_button/loading_button.dart
@@ -13,7 +13,7 @@ class LoadingButton extends StatelessWidget {
   final EdgeInsetsGeometry padding;
 
   const LoadingButton({
-    Key? key,
+    super.key,
     required this.controller,
     this.normalIcon = const SizedBox(),
     this.bgColor = const Color(0xFF03a1e4),
@@ -26,7 +26,7 @@ class LoadingButton extends StatelessWidget {
     ),
     this.onPressed,
     this.padding = const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/core/lib/presentation/common_widget/media_picker.dart
+++ b/core/lib/presentation/common_widget/media_picker.dart
@@ -516,7 +516,7 @@ class MediaPickerStyle {
 
 class MediaPickerWidget extends StatefulWidget {
   const MediaPickerWidget({
-    Key? key,
+    super.key,
     required this.controller,
     this.config = const MediaPickerConfig(),
     this.style = const MediaPickerStyle(),
@@ -524,7 +524,7 @@ class MediaPickerWidget extends StatefulWidget {
     this.onTap,
     this.canBeDeleteWhen,
     this.errorController,
-  }) : super(key: key);
+  });
 
   final MediaPickerController controller;
   final MediaPickerConfig config;
@@ -816,14 +816,13 @@ class _MediaPickerWidgetState extends CoreStateBase<MediaPickerWidget>
 
 class _MediaEmptyStateWidget extends StatelessWidget {
   const _MediaEmptyStateWidget({
-    Key? key,
     required this.medias,
     required this.config,
     required this.style,
     required this.onTap,
     required this.l10n,
     this.errorController,
-  }) : super(key: key);
+  });
 
   final List<MediaPicked> medias;
   final MediaPickerConfig config;
@@ -844,7 +843,7 @@ class _MediaEmptyStateWidget extends StatelessWidget {
           borderRadius: style.borderRadius?.let(BorderRadius.all),
           child: AnimatedBuilder(
             animation: Listenable.merge([
-              if (errorController != null) errorController!,
+              ?errorController,
             ]),
             builder: (context, child) {
               final hasError = errorController?.value != null;
@@ -903,7 +902,6 @@ class _MediaEmptyStateWidget extends StatelessWidget {
 
 class _MediaItemWidget extends StatelessWidget {
   const _MediaItemWidget({
-    Key? key,
     required this.media,
     required this.canDelete,
     required this.onRemove,
@@ -912,7 +910,7 @@ class _MediaItemWidget extends StatelessWidget {
     required this.onViewMedia,
     this.onTap,
     this.borderRadius,
-  }) : super(key: key);
+  });
 
   final MediaPicked media;
   final bool canDelete;

--- a/core/lib/presentation/common_widget/multiple_selection_dialog.dart
+++ b/core/lib/presentation/common_widget/multiple_selection_dialog.dart
@@ -15,7 +15,7 @@ class MultipleSelectionDialog<T> extends StatefulWidget {
   final bool Function(T, T)? compareFunction;
 
   const MultipleSelectionDialog({
-    Key? key,
+    super.key,
     required this.items,
     this.initialItems,
     this.compareFunction,
@@ -23,7 +23,7 @@ class MultipleSelectionDialog<T> extends StatefulWidget {
     required this.onCancel,
     required this.itemBuilder,
     required this.filterFn,
-  }) : super(key: key);
+  });
 
   @override
   _MultipleSelectionDialog<T> createState() => _MultipleSelectionDialog<T>();

--- a/core/lib/presentation/common_widget/notice_dialog_with_options.dart
+++ b/core/lib/presentation/common_widget/notice_dialog_with_options.dart
@@ -17,7 +17,7 @@ class NoticeDialogWithOptions extends StatelessWidget {
   final BuildContext parentContext;
 
   const NoticeDialogWithOptions({
-    Key? key,
+    super.key,
     required this.title,
     required this.options,
     required this.parentContext,
@@ -28,15 +28,15 @@ class NoticeDialogWithOptions extends StatelessWidget {
     this.onConfirmed,
     this.onCanceled,
     this.initialValue,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
-    final dismissFunc = () {
+    void dismissFunc() {
       if (dismissWhenAction) {
         Navigator.of(context, rootNavigator: useRootNavigator).pop();
       }
-    };
+    }
 
     final selectedOptionNotifier = ValueNotifier<int?>(initialValue);
     final localization = parentContext.coreL10n;

--- a/core/lib/presentation/common_widget/selection_dialog.dart
+++ b/core/lib/presentation/common_widget/selection_dialog.dart
@@ -13,13 +13,13 @@ class SelectionDialog<T> extends StatefulWidget {
   final Widget? widgetAll;
 
   const SelectionDialog({
-    Key? key,
+    super.key,
     required this.items,
     required this.onSelected,
     required this.itemBuilder,
     required this.filterFn,
     this.widgetAll,
-  }) : super(key: key);
+  });
 
   @override
   _SelectionDialogState<T> createState() => _SelectionDialogState<T>();

--- a/core/lib/presentation/common_widget/submit_succeed_dailog.dart
+++ b/core/lib/presentation/common_widget/submit_succeed_dailog.dart
@@ -12,14 +12,14 @@ class SubmitSucceedDailog extends StatelessWidget {
   final void Function() onConfirm;
 
   const SubmitSucceedDailog({
-    Key? key,
+    super.key,
     required this.title,
     this.titleColor,
     required this.message,
     required this.btnTitle,
     required this.onConfirm,
     required this.icon,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/core/lib/presentation/common_widget/unsupported_page.dart
+++ b/core/lib/presentation/common_widget/unsupported_page.dart
@@ -8,7 +8,7 @@ import 'forms/screen_form.dart';
 class UnsupportedPage extends StatelessWidget {
   final String? title;
   final String? msg;
-  const UnsupportedPage({Key? key, this.title, this.msg}) : super(key: key);
+  const UnsupportedPage({super.key, this.title, this.msg});
 
   @override
   Widget build(BuildContext context) {

--- a/core/lib/presentation/common_widget/video_viewer_screen.dart
+++ b/core/lib/presentation/common_widget/video_viewer_screen.dart
@@ -20,7 +20,7 @@ class VideoViewerArgs {
 class VideoViewerScreen extends StatefulWidget {
   final VideoViewerArgs? args;
 
-  const VideoViewerScreen({Key? key, this.args}) : super(key: key);
+  const VideoViewerScreen({super.key, this.args});
 
   @override
   State<VideoViewerScreen> createState() => _VideoViewerScreenState();

--- a/core/lib/presentation/common_widget/view_more.dart
+++ b/core/lib/presentation/common_widget/view_more.dart
@@ -12,14 +12,14 @@ class HtmlWidgetWithViewMore extends StatelessWidget {
   final TextStyle? style;
 
   const HtmlWidgetWithViewMore({
-    Key? key,
+    super.key,
     required this.htmlContent,
     this.expand = false,
     required this.viewMore,
     required this.seeLess,
     this.minHeight = 200,
     this.style,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/core/lib/presentation/modules/dev_mode/design_system/design_system_screen.dart
+++ b/core/lib/presentation/modules/dev_mode/design_system/design_system_screen.dart
@@ -12,7 +12,7 @@ import 'pages/typography_page.dart';
 class DesignSystemScreen extends StatefulWidget {
   static const String routeName = '/dev-mode-design-system';
 
-  const DesignSystemScreen({Key? key}) : super(key: key);
+  const DesignSystemScreen({super.key});
 
   @override
   State<DesignSystemScreen> createState() => _DesignSystemScreenState();

--- a/core/lib/presentation/modules/dev_mode/design_system/pages/dialogs_and_picker_page.dart
+++ b/core/lib/presentation/modules/dev_mode/design_system/pages/dialogs_and_picker_page.dart
@@ -31,6 +31,9 @@ class DialogAndPickerPage extends StatelessWidget {
               title: 'title',
             );
 
+            if (!context.mounted) {
+              return;
+            }
             showToast(context, 'Reason: $res');
           },
         ),

--- a/core/lib/presentation/modules/dev_mode/design_system/pages/story_book.dart
+++ b/core/lib/presentation/modules/dev_mode/design_system/pages/story_book.dart
@@ -29,13 +29,13 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
     return <Widget>[
       StoryWidgetBox(
         title: 'fl_ui/AnimatedDropdownIcon',
-        builder: (context, _, __) =>
+        builder: (context, _, _) =>
             AnimatedDropdownIcon(isExpanded: tick % 2 != 0, size: 56),
       ),
       StoryWidgetBox(
         title: 'fl_ui/AvailabilityWidget',
-        description: '${tick % 2 == 0 ? 'Enabled' : 'Disabled'}',
-        builder: (context, _, __) => AvailabilityWidget(
+        description: tick % 2 == 0 ? 'Enabled' : 'Disabled',
+        builder: (context, _, _) => AvailabilityWidget(
           enable: tick % 2 == 0,
           child: Text(
             'data',
@@ -47,7 +47,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
       ),
       StoryWidgetBox(
         title: 'fl_ui/BadgeBox',
-        builder: (context, _, __) => Align(
+        builder: (context, _, _) => Align(
           child: BadgeBox(
             count: tick,
             child: const Icon(Icons.notifications, size: 32),
@@ -56,7 +56,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
       ),
       StoryWidgetBox(
         title: 'fl_ui/BannerWidget',
-        builder: (context, _, __) {
+        builder: (context, _, _) {
           final banners = <String>[
             'https://storage.googleapis.com/cms-storage-bucket/images/image001.width-1440.format-webp-lossless.webp',
             'https://storage.googleapis.com/cms-storage-bucket/images/image001.width-1440.format-webp-lossless.webp',
@@ -68,7 +68,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
                   (e) => Expanded(
                     child: StoryWidgetBox(
                       description: e.toString(),
-                      builder: (context, _, __) => BannerWidget<String>(
+                      builder: (context, _, _) => BannerWidget<String>(
                         banners: banners,
                         ratio: 3 / 1,
                         getImageUrl: (e) => e,
@@ -92,7 +92,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
       ),
       StoryWidgetBox(
         title: 'fl_ui/BoxColor',
-        builder: (context, _, __) {
+        builder: (context, _, _) {
           return Wrap(
             children: [
               BoxColor(
@@ -118,7 +118,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
       ),
       StoryWidgetBox(
         title: 'fl_ui/CheckBox',
-        builder: (context, _, __) {
+        builder: (context, _, _) {
           return Column(
             children: [
               CheckboxWithTitle(
@@ -131,7 +131,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
       ),
       StoryWidgetBox(
         title: 'fl_ui/CheckBoxGroup',
-        builder: (context, _, __) {
+        builder: (context, _, _) {
           final items = List.generate(3, (index) => index);
           return Column(
             children: [
@@ -151,7 +151,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
       ),
       StoryWidgetBox(
         title: 'fl_ui/Radio',
-        builder: (context, _, __) {
+        builder: (context, _, _) {
           return Column(
             children: [
               RadioButtonWithTitle(
@@ -166,7 +166,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
               ),
               StoryWidgetBox(
                 title: 'fl_ui/FlRadioGroup',
-                builder: (context, _, __) {
+                builder: (context, _, _) {
                   final items = List.generate(3, (index) => index);
                   return Column(
                     children: [
@@ -188,7 +188,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
       ),
       StoryWidgetBox(
         title: 'fl_ui/EnViSwitch',
-        builder: (context, _, __) {
+        builder: (context, _, _) {
           return Center(
             child: EnViSwitch(
               isVILanguage:
@@ -205,7 +205,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
       ),
       StoryWidgetBox(
         title: 'fl_ui/VerticalStepper',
-        builder: (context, _, __) {
+        builder: (context, _, _) {
           return VerticalStepper(
             steps: List.generate(
               3,
@@ -267,7 +267,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
       ),
       StoryWidgetBox(
         title: 'fl_ui/InfoItem',
-        builder: (context, _, __) {
+        builder: (context, _, _) {
           return const Column(
             children: [
               InfoItem(
@@ -293,7 +293,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
       ),
       StoryWidgetBox(
         title: 'fl_ui/MenuItemWidget',
-        builder: (context, _, __) {
+        builder: (context, _, _) {
           return Column(
             children: [
               MenuItemWidget(
@@ -376,7 +376,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
       StoryWidgetBox(
         title: 'fl_ui/ReceiptShapeBorder',
         description: 'Demo ReceiptShapeBorder with Separator widget',
-        builder: (context, _, __) {
+        builder: (context, _, _) {
           return Material(
             color: themeColor.surface,
             shape: ReceiptShapeBorder(
@@ -401,7 +401,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
       ),
       StoryWidgetBox(
         title: 'fl_ui/LayoutSwitching',
-        builder: (context, _, __) {
+        builder: (context, _, _) {
           return GridView.count(
             physics: const NeverScrollableScrollPhysics(),
             shrinkWrap: true,
@@ -414,7 +414,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
               ...SwitchingAnimation.values.map(
                 (e) => StoryWidgetBox(
                   description: e.toString(),
-                  builder: (context, _, __) {
+                  builder: (context, _, _) {
                     return ClipRRect(
                       child: LayoutSwitching(
                         duration: const Duration(seconds: 1),
@@ -441,7 +441,7 @@ class _WidgetStoryBookState extends State<WidgetStoryBook> {
       ),
       StoryWidgetBox(
         title: 'core/GenderSelection',
-        builder: (context, _, __) {
+        builder: (context, _, _) {
           return GenderSelection(
             required: true,
             title: 'Gender',

--- a/core/lib/presentation/modules/dev_mode/design_system/pages/typography_page.dart
+++ b/core/lib/presentation/modules/dev_mode/design_system/pages/typography_page.dart
@@ -2,7 +2,7 @@ import 'package:fl_theme/fl_theme.dart';
 import 'package:flutter/material.dart';
 
 class TypographyPage extends StatelessWidget {
-  const TypographyPage({Key? key}) : super(key: key);
+  const TypographyPage({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -32,11 +32,11 @@ size: ${style.fontSize}''',
 
 class TextStyleItem extends StatelessWidget {
   const TextStyleItem({
-    Key? key,
+    super.key,
     required this.name,
     required this.style,
     required this.text,
-  }) : super(key: key);
+  });
 
   final String name;
   final TextStyle style;

--- a/core/lib/presentation/modules/dev_mode/log_viewer/log_viewer_screen.dart
+++ b/core/lib/presentation/modules/dev_mode/log_viewer/log_viewer_screen.dart
@@ -10,7 +10,7 @@ import '../../../extentions/context_extention.dart';
 class LogViewerScreen extends StatefulWidget {
   static const String routeName = '/log-viewer';
 
-  const LogViewerScreen({Key? key}) : super(key: key);
+  const LogViewerScreen({super.key});
 
   @override
   State<LogViewerScreen> createState() => _LogViewerScreenState();
@@ -49,7 +49,7 @@ class _LogViewerScreenState extends State<LogViewerScreen> {
             ),
           );
         },
-        separatorBuilder: (_, __) => const Divider(height: 16, thickness: 1),
+        separatorBuilder: (_, _) => const Divider(height: 16, thickness: 1),
         itemCount: logs.length,
       ),
     );

--- a/core/lib/presentation/modules/dev_mode/log_viewer/network/network_log_viewer_screen.dart
+++ b/core/lib/presentation/modules/dev_mode/log_viewer/network/network_log_viewer_screen.dart
@@ -6,7 +6,7 @@ import '../../../../../core.dart';
 class NetworkLogViewerScreen extends StatefulWidget {
   static const String routeName = '/network-log-viewer';
 
-  const NetworkLogViewerScreen({Key? key}) : super(key: key);
+  const NetworkLogViewerScreen({super.key});
 
   @override
   State<NetworkLogViewerScreen> createState() => _NetworkLogViewerScreenState();
@@ -39,7 +39,7 @@ class _NetworkLogViewerScreenState extends State<NetworkLogViewerScreen> {
             child: NetworkLogItem(log: log),
           );
         },
-        separatorBuilder: (_, __) => const SizedBox(height: 16),
+        separatorBuilder: (_, _) => const SizedBox(height: 16),
         itemCount: logs.length,
       ),
     );

--- a/core/lib/presentation/modules/document_viewer/document_viewer_screen.dart
+++ b/core/lib/presentation/modules/document_viewer/document_viewer_screen.dart
@@ -25,7 +25,7 @@ class DocumentViewerArgs {
 
 class DocumentViewerScreen extends StatefulWidget {
   static const String routeName = '/document-viewer';
-  const DocumentViewerScreen({Key? key, required this.args}) : super(key: key);
+  const DocumentViewerScreen({super.key, required this.args});
 
   final DocumentViewerArgs args;
 
@@ -46,10 +46,10 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
             iconSize: 20,
             padding: EdgeInsets.zero,
             splashRadius: 20,
-            icon: Container(
+            icon: const SizedBox(
               width: 40,
               height: 40,
-              child: const Icon(
+              child: Icon(
                 Icons.download,
                 size: 20,
                 color: Color(0xFF767676),

--- a/core/lib/presentation/modules/document_viewer/viewers/pdf_viewer.dart
+++ b/core/lib/presentation/modules/document_viewer/viewers/pdf_viewer.dart
@@ -8,8 +8,7 @@ class PDFViewer extends StatefulWidget {
   final String url;
   final Future<Uint8List?> Function({required String url}) getDataFrom;
 
-  const PDFViewer({Key? key, required this.url, required this.getDataFrom})
-    : super(key: key);
+  const PDFViewer({super.key, required this.url, required this.getDataFrom});
 
   @override
   _PDFViewerState createState() => _PDFViewerState();

--- a/core/lib/presentation/theme/theme_bottom_sheet.dart
+++ b/core/lib/presentation/theme/theme_bottom_sheet.dart
@@ -92,35 +92,33 @@ class ThemeBottomSheet {
                       textAlign: TextAlign.center,
                     ),
                   ),
-                ...action.entries
-                    .map<Widget>(
-                      (e) => InkWell(
-                        onTap: e.value.call(),
-                        child: Container(
-                          decoration: BoxDecoration(
-                            border: Border(
-                              top: BorderSide(
-                                width: 1,
-                                color: Colors.grey[400]!,
-                              ),
-                            ),
-                          ),
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 8,
-                            vertical: 18,
-                          ),
-                          child: Text(
-                            e.key,
-                            style: theme.textTheme.headlineSmall?.copyWith(
-                              color: Colors.blue,
-                              fontWeight: FontWeight.normal,
-                            ),
-                            textAlign: TextAlign.center,
+                ...action.entries.map<Widget>(
+                  (e) => InkWell(
+                    onTap: e.value.call(),
+                    child: Container(
+                      decoration: BoxDecoration(
+                        border: Border(
+                          top: BorderSide(
+                            width: 1,
+                            color: Colors.grey[400]!,
                           ),
                         ),
                       ),
-                    )
-                    .toList(),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 18,
+                      ),
+                      child: Text(
+                        e.key,
+                        style: theme.textTheme.headlineSmall?.copyWith(
+                          color: Colors.blue,
+                          fontWeight: FontWeight.normal,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                ),
               ],
             ),
           ),

--- a/core/lib/presentation/theme/theme_dialog.dart
+++ b/core/lib/presentation/theme/theme_dialog.dart
@@ -38,14 +38,15 @@ abstract class ThemeDialog {
     void Function()? onCanceled,
     Widget? icon,
   }) {
-    final dismissFunc = (bool result) {
+    void dismissFunc(bool result) {
       if (dismissWhenAction) {
         Navigator.of(context, rootNavigator: useRootNavigator).pop(result);
       }
-    };
+    }
+
     final theme = context.theme;
 
-    final showAndroidDialog = () => AlertDialog(
+    AlertDialog showAndroidDialog() => AlertDialog(
       icon: icon,
       title: Text(
         title ?? inform,
@@ -179,24 +180,25 @@ abstract class ThemeDialog {
   }) {
     final _icReason = controller;
     Widget body;
-    final dismissFunc = () {
+    void dismissFunc() {
       if (dismissWhenAction) {
         Navigator.of(
           context,
           rootNavigator: useRootNavigator,
         ).pop(_icReason.text);
       }
-    };
+    }
+
     final theme = context.theme;
 
-    final showAndroidDialog = () => AlertDialog(
+    AlertDialog showAndroidDialog() => AlertDialog(
       title: Text(title ?? inform, style: theme.textTheme.headlineSmall),
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           icon ?? const SizedBox.shrink(),
           InputTitleWidget(title: message, required: false),
-          if (additionalWidget != null) additionalWidget,
+          ?additionalWidget,
           InputContainer(controller: _icReason, maxLines: 6, hint: hint),
         ],
       ),
@@ -272,7 +274,7 @@ abstract class ThemeDialog {
             children: [
               icon ?? const SizedBox.shrink(),
               InputTitleWidget(title: message, required: false),
-              if (additionalWidget != null) additionalWidget,
+              ?additionalWidget,
               InputContainer(controller: _icReason, maxLines: 4, hint: hint),
             ],
           ),
@@ -321,13 +323,14 @@ abstract class ThemeDialog {
     bool barrierDismissible = true,
     Widget? icon,
   }) {
-    final dismissFunc = () {
+    void dismissFunc() {
       if (dismissWhenAction) {
         Navigator.of(context, rootNavigator: useRootNavigator).pop();
       }
-    };
+    }
+
     final theme = context.theme;
-    final showAndroidDialog = () => PopScope(
+    PopScope showAndroidDialog() => PopScope(
       canPop: barrierDismissible,
       child: AlertDialog(
         title: Text(title ?? inform, style: theme.textTheme.headlineSmall),
@@ -429,26 +432,24 @@ abstract class ThemeDialog {
           ),
         ),
         actions: [
-          ...actions.entries
-              .map<TextButton>(
-                (e) => TextButton(
-                  key: ValueKey('ActionDialog_${e.key}'),
-                  onPressed: () {
-                    if (dimissWhenSelect) {
-                      Navigator.of(
-                        context,
-                        rootNavigator: useRootNavigator,
-                      ).pop();
-                    }
-                    e.value.call();
-                  },
-                  child: Text(
-                    e.key,
-                    style: TextStyle(color: context.themeColor.primary),
-                  ),
-                ),
-              )
-              .toList(),
+          ...actions.entries.map<TextButton>(
+            (e) => TextButton(
+              key: ValueKey('ActionDialog_${e.key}'),
+              onPressed: () {
+                if (dimissWhenSelect) {
+                  Navigator.of(
+                    context,
+                    rootNavigator: useRootNavigator,
+                  ).pop();
+                }
+                e.value.call();
+              },
+              child: Text(
+                e.key,
+                style: TextStyle(color: context.themeColor.primary),
+              ),
+            ),
+          ),
           TextButton(
             key: const ValueKey('ActionDialog_close_btn'),
             onPressed: () {
@@ -631,14 +632,15 @@ abstract class ThemeDialog {
     void Function()? onCanceled,
   }) {
     final _icValidate = controller;
-    final dismissFunc = () {
+    void dismissFunc() {
       if (dismissWhenAction) {
         Navigator.of(context, rootNavigator: useRootNavigator).pop();
       }
-    };
+    }
+
     final theme = context.theme;
 
-    final showAndroidDialog = () => AlertDialog(
+    AlertDialog showAndroidDialog() => AlertDialog(
       title: Text(title ?? inform, style: theme.textTheme.headlineSmall),
       content: Column(
         mainAxisSize: MainAxisSize.min,

--- a/core/pubspec.lock
+++ b/core/pubspec.lock
@@ -82,7 +82,7 @@ packages:
     source: hosted
     version: "3.0.0"
   badges:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: badges
       sha256: a7b6bbd60dce418df0db3058b53f9d083c22cdb5132a052145dc267494df0b84
@@ -162,7 +162,7 @@ packages:
     source: hosted
     version: "2.13.1"
   built_collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
@@ -202,7 +202,7 @@ packages:
     source: hosted
     version: "1.3.1"
   carousel_slider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: carousel_slider
       sha256: bcc61735345c9ab5cb81073896579e735f81e35fd588907a393143ea986be8ff
@@ -250,7 +250,7 @@ packages:
     source: hosted
     version: "4.11.0"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
@@ -362,7 +362,7 @@ packages:
     source: hosted
     version: "0.1.6"
   dio:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: dio
       sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
@@ -378,7 +378,7 @@ packages:
     source: hosted
     version: "2.1.1"
   dots_indicator:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: dots_indicator
       sha256: f1599baa429936ba87f06ae5f2adc920a367b16d08f74db58c3d0f6e93bcdb5c
@@ -793,6 +793,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -871,7 +879,7 @@ packages:
     source: hosted
     version: "5.2.2"
   flutter_svg:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_svg
       sha256: b9c2ad5872518a27507ab432d1fb97e8813b05f0fc693f9d40fad06d073e0678
@@ -961,7 +969,7 @@ packages:
     source: hosted
     version: "0.16.1"
   fwfh_chewie:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: fwfh_chewie
       sha256: ae74fc26798b0e74f3983f7b851e74c63b9eeb2d3015ecd4b829096b2c3f8818
@@ -1113,7 +1121,7 @@ packages:
     source: hosted
     version: "4.4.0"
   html:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: html
       sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
@@ -1384,8 +1392,16 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.6"
-  logger:
+  lints:
     dependency: transitive
+    description:
+      name: lints
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
+  logger:
+    dependency: "direct main"
     description:
       name: logger
       sha256: "55d6c23a6c15db14920e037fe7e0dc32e7cdaf3b64b4b25df2d541b5b6b81c0c"
@@ -1496,7 +1512,7 @@ packages:
     source: hosted
     version: "3.2.1"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
@@ -1575,14 +1591,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.9.2"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   permission_handler:
     dependency: "direct main"
     description:
@@ -1744,7 +1752,7 @@ packages:
     source: hosted
     version: "4.1.0"
   retrofit:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: retrofit
       sha256: "0f629ed26b2c48c66fe54bd548313c6fdf7955be18bff37e08a46dd3f97f8eaf"
@@ -1760,7 +1768,7 @@ packages:
     source: hosted
     version: "10.2.3"
   rxdart:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: rxdart
       sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
@@ -1885,7 +1893,7 @@ packages:
     source: hosted
     version: "7.0.0"
   sqflite:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: sqflite
       sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03
@@ -2021,7 +2029,7 @@ packages:
     source: hosted
     version: "1.1.0"
   url_launcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher
       sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
@@ -2213,7 +2221,7 @@ packages:
     source: hosted
     version: "1.1.4"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -86,7 +86,7 @@ dependencies:
   collection: ^1.19.1
   dio: ^5.4.0
   dots_indicator: ^2.1.2
-  flutter_svg: ^2.2.1
+  flutter_svg: ^2.2.0
   fwfh_chewie: ^0.16.1
   html: ^0.15.6
   logger: ^2.6.1

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -77,12 +77,32 @@ dependencies:
     path: ../plugins/fl_ui
   fl_theme:
     path: ../plugins/fl_theme
+
+  # Direct deps previously resolved only transitively — declared for
+  # depend_on_referenced_packages (several are re-exported from core.dart).
+  badges: ^3.1.2
+  built_collection: ^5.1.1
+  carousel_slider: ^5.1.1
+  collection: ^1.19.1
+  dio: ^5.4.0
+  dots_indicator: ^2.1.2
+  flutter_svg: ^2.2.1
+  fwfh_chewie: ^0.16.1
+  html: ^0.15.6
+  logger: ^2.6.1
+  path: ^1.9.1
+  retrofit: ^4.9.2
+  rxdart: ^0.28.0
+  sqflite: ^2.4.2
+  url_launcher: ^6.3.2
+  web: ^1.1.1
   fl_media:
     path: ../plugins/fl_media
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^6.0.0
   build_runner: ^2.0.4
   retrofit_generator: 10.2.3
   hive_ce_generator: ^1.9.3

--- a/makefile
+++ b/makefile
@@ -12,15 +12,8 @@ PACKAGE_DIRS := apps/main core modules/data_source \
 	plugins/fl_media plugins/fl_media/example \
 	plugins/fl_navigation plugins/fl_navigation/example \
 	tools/module_generator
-TEST_PACKAGE_DIRS := apps/main core \
-	plugins/fl_ui plugins/fl_ui/example \
-	plugins/fl_utils \
-	plugins/fl_theme plugins/fl_theme/example \
-	plugins/fl_media/example \
-	plugins/fl_navigation \
-	tools/module_generator
 ANALYZE_DIRS := $(if $(PACKAGES),$(PACKAGES),$(PACKAGE_DIRS))
-TEST_DIRS := $(if $(PACKAGES),$(PACKAGES),$(TEST_PACKAGE_DIRS))
+TEST_DIRS := $(if $(PACKAGES),$(PACKAGES),$(PACKAGE_DIRS))
 
 # Main targets
 .PHONY: setup build run test analyze check format_check clean asset asset_main asset_fl_ui asset_all lang format help coverage_main gen gen_all gen_core gen_data_source gen_main \
@@ -444,7 +437,7 @@ analyze:
 test:
 	@status=0; \
 	for package in $(TEST_DIRS); do \
-		if find "$$package/test" -name '*_test.dart' -print -quit | grep -q .; then \
+		if [ -d "$$package/test" ] && find "$$package/test" -name '*_test.dart' -print -quit | grep -q .; then \
 			printf "Testing %s... " "$$package"; \
 			log_file=$$(mktemp); \
 			if (cd "$$package" && $(FLUTTER) test > "$$log_file" 2>&1); then \

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ ANALYZE_DIRS := $(if $(PACKAGES),$(PACKAGES),$(PACKAGE_DIRS))
 TEST_DIRS := $(if $(PACKAGES),$(PACKAGES),$(TEST_PACKAGE_DIRS))
 
 # Main targets
-.PHONY: setup build run test analyze clean asset asset_main asset_fl_ui asset_all lang format help coverage_main gen gen_all gen_core gen_data_source gen_main \
+.PHONY: setup build run test analyze check format_check clean asset asset_main asset_fl_ui asset_all lang format help coverage_main gen gen_all gen_core gen_data_source gen_main \
 	pub_get pub_get_plugins pub_get_core pub_get_main pub_get_fl_ui pub_get_fl_utils pub_get_fl_theme pub_get_fl_media pub_get_fl_navigation \
 	app_identifier create_project reset run_web_dev run_web_staging build_web clean_force run_module_generator gen_translation apply_translation
 
@@ -75,12 +75,14 @@ help:
 	@echo "  make build_web          - Build web app"
 	@echo ""
 	@echo "Testing and Coverage:"
+	@echo "  make check              - Definition of done: analyze + format check + tests (run before calling work complete)"
 	@echo "  make analyze           - Run flutter analyze for all packages, or PACKAGES=\"apps/main core\""
 	@echo "  make test              - Run tests for packages with test files, or PACKAGES=\"apps/main core\""
 	@echo "  make coverage_main      - Generate test coverage report for main app"
 	@echo ""
 	@echo "Maintenance:"
 	@echo "  make format             - Format all Dart code"
+	@echo "  make format_check       - Verify formatting without rewriting files"
 	@echo "  make clean              - Clean the project"
 	@echo "  make clean_force        - Clean with force option"
 	@echo "  make run_module_generator - Run module generator (interactive)"
@@ -275,19 +277,37 @@ gen:
 # Maintenance
 ################################################################################
 
+# Hand-written Dart sources: everything `format` and `format_check` operate on.
+# Generated output and vendored deps are excluded — they are not ours to reformat.
+FIND_HAND_WRITTEN_DART := find . -name '*.dart' \
+	-not -path '*/.dart_tool/*' \
+	-not -path '*/build/*' \
+	-not -path '*/node_modules/*' \
+	-not -path '*/lib/generated/*' \
+	-not -path '*/lib/l10n/generated/*' \
+	-not -path '*/lib/src/l10n/generated/*' \
+	-not -name '*.config.dart' \
+	-not -name '*.freezed.dart' \
+	-not -name '*.g.dart' \
+	-not -name '*.module.dart'
+
 # Format hand-written Dart code
 format:
-	@find . -name '*.dart' \
-		-not -path '*/.dart_tool/*' \
-		-not -path '*/build/*' \
-		-not -path '*/lib/generated/*' \
-		-not -path '*/lib/l10n/generated/*' \
-		-not -path '*/lib/src/l10n/generated/*' \
-		-not -name '*.config.dart' \
-		-not -name '*.freezed.dart' \
-		-not -name '*.g.dart' \
-		-not -name '*.module.dart' \
-		-print0 | xargs -0 $(DART) format
+	@$(FIND_HAND_WRITTEN_DART) -print0 | xargs -0 $(DART) format
+
+# Verify formatting without rewriting files (same scope as `format`)
+format_check:
+	@log_file=$$(mktemp); \
+	if $(FIND_HAND_WRITTEN_DART) -print0 \
+		| xargs -0 $(DART) format --output=none --set-exit-if-changed > "$$log_file" 2>&1; then \
+		echo "Formatting ok"; \
+		rm -f "$$log_file"; \
+	else \
+		echo "Formatting failed - these files need 'make format':"; \
+		grep -oE 'Changed [^ ]+\.dart' "$$log_file" || cat "$$log_file"; \
+		rm -f "$$log_file"; \
+		exit 1; \
+	fi
 
 # Run module generator
 run_module_generator:
@@ -395,6 +415,11 @@ build_web:
 ################################################################################
 # Testing and Coverage
 ################################################################################
+
+# Definition of done: a change is not complete until this passes.
+# Fails on analyzer infos too, which is how lint debt accumulates unnoticed.
+check: analyze format_check test
+	@echo "check: analyze + format + tests all clean"
 
 # Analyze all packages
 analyze:

--- a/modules/data_source/analysis_options.yaml
+++ b/modules/data_source/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   language:

--- a/modules/data_source/lib/data_source.dart
+++ b/modules/data_source/lib/data_source.dart
@@ -1,3 +1,3 @@
-library data_source;
+library;
 
 export 'src/sources.dart';

--- a/modules/data_source/pubspec.lock
+++ b/modules/data_source/pubspec.lock
@@ -369,7 +369,7 @@ packages:
     source: hosted
     version: "0.1.6"
   dio:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: dio
       sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
@@ -1272,7 +1272,7 @@ packages:
     source: hosted
     version: "0.2.2"
   injectable:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: injectable
       sha256: "1b86fab6a98c11a97e5c718afb00e628d47d183c2a2256392e995a4c561141c1"
@@ -1598,14 +1598,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.9.2"
-  pedantic:
-    dependency: "direct main"
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   permission_handler:
     dependency: transitive
     description:
@@ -1767,7 +1759,7 @@ packages:
     source: hosted
     version: "4.1.0"
   retrofit:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: retrofit
       sha256: "0f629ed26b2c48c66fe54bd548313c6fdf7955be18bff37e08a46dd3f97f8eaf"

--- a/modules/data_source/pubspec.yaml
+++ b/modules/data_source/pubspec.yaml
@@ -11,12 +11,15 @@ dependencies:
   flutter:
     sdk: flutter
 
-  pedantic: ^1.11.1
   uuid: any
   freezed_annotation: 3.1.0
 
   core:
     path: ../../core
+
+  dio: ^5.4.0
+  injectable: ^2.5.1
+  retrofit: ^4.9.2
 
 dev_dependencies:
   flutter_test:

--- a/plugins/fl_media/analysis_options.yaml
+++ b/plugins/fl_media/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   language:
@@ -6,6 +6,8 @@ analyzer:
   errors:
     # allow having TODOs in the code
     todo: ignore
+    # Widget State subclasses intentionally expose private types via builder APIs.
+    library_private_types_in_public_api: ignore
   exclude:
     # exclude files
     - .dart_tool/**

--- a/plugins/fl_media/example/pubspec.lock
+++ b/plugins/fl_media/example/pubspec.lock
@@ -445,10 +445,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "6.0.0"
   flutter_localizations:
     dependency: transitive
     description: flutter
@@ -708,10 +708,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "6.1.0"
   logger:
     dependency: transitive
     description:

--- a/plugins/fl_media/example/pubspec.lock
+++ b/plugins/fl_media/example/pubspec.lock
@@ -864,14 +864,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   petitparser:
     dependency: transitive
     description:

--- a/plugins/fl_media/example/pubspec.yaml
+++ b/plugins/fl_media/example/pubspec.yaml
@@ -39,7 +39,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/plugins/fl_media/lib/fl_media.dart
+++ b/plugins/fl_media/lib/fl_media.dart
@@ -1,4 +1,4 @@
-library fl_media;
+library;
 
 export 'package:extended_image/extended_image.dart' hide Request;
 

--- a/plugins/fl_media/lib/src/modules/image_cropper/image_cropper.action.dart
+++ b/plugins/fl_media/lib/src/modules/image_cropper/image_cropper.action.dart
@@ -15,6 +15,9 @@ extension on _ImageCropperScreenState {
     }
     final imageFile = await _saveTempFile(fileData);
     hideLoading();
+    if (!mounted) {
+      return;
+    }
     Navigator.of(context).pop(imageFile);
   }
 

--- a/plugins/fl_media/lib/src/modules/image_cropper/image_cropper_screen.dart
+++ b/plugins/fl_media/lib/src/modules/image_cropper/image_cropper_screen.dart
@@ -19,9 +19,9 @@ class ImageCropperScreen extends StatefulWidget {
   static const String routeName = '/image-cropper';
 
   const ImageCropperScreen({
-    Key? key,
+    super.key,
     required this.imagefile,
-  }) : super(key: key);
+  });
 
   final File imagefile;
 

--- a/plugins/fl_media/lib/src/modules/image_cropper/image_cropper_screen_web.dart
+++ b/plugins/fl_media/lib/src/modules/image_cropper/image_cropper_screen_web.dart
@@ -7,9 +7,9 @@ class ImageCropperScreen extends StatelessWidget {
   final File imagefile;
 
   const ImageCropperScreen({
-    Key? key,
+    super.key,
     required this.imagefile,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/plugins/fl_media/lib/src/widgets/hero_widget.dart
+++ b/plugins/fl_media/lib/src/widgets/hero_widget.dart
@@ -4,12 +4,12 @@ import 'package:flutter/material.dart';
 /// make hero better when slide out
 class HeroWidget extends StatefulWidget {
   const HeroWidget({
-    Key? key,
+    super.key,
     required this.child,
     required this.tag,
     required this.slidePagekey,
     this.slideType = SlideType.onlyImage,
-  }) : super(key: key);
+  });
 
   final Widget child;
   final SlideType slideType;

--- a/plugins/fl_media/lib/src/widgets/image_view.dart
+++ b/plugins/fl_media/lib/src/widgets/image_view.dart
@@ -19,7 +19,7 @@ typedef ImageViewErrorBuilder =
 
 class ImageView extends StatelessWidget {
   const ImageView({
-    Key? key,
+    super.key,
     required this.source,
     this.width,
     this.height,

--- a/plugins/fl_media/lib/src/widgets/image_zoom.dart
+++ b/plugins/fl_media/lib/src/widgets/image_zoom.dart
@@ -11,9 +11,9 @@ class ImageZoom extends StatefulWidget {
   final String url;
 
   const ImageZoom({
-    Key? key,
+    super.key,
     required this.url,
-  }) : super(key: key);
+  });
 
   @override
   State<ImageZoom> createState() => _ImageZoomState();

--- a/plugins/fl_media/pubspec.lock
+++ b/plugins/fl_media/pubspec.lock
@@ -825,7 +825,7 @@ packages:
     source: hosted
     version: "1.1.0"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
@@ -872,14 +872,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
-  pedantic:
-    dependency: "direct main"
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   petitparser:
     dependency: transitive
     description:

--- a/plugins/fl_media/pubspec.yaml
+++ b/plugins/fl_media/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   chewie: ^1.8.5
   visibility_detector: ^0.4.0+2
 
-  pedantic: ^1.11.1
+  path_provider: ^2.1.5
 
   fl_utils:
     path: ../fl_utils

--- a/plugins/fl_navigation/analysis_options.yaml
+++ b/plugins/fl_navigation/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   language:

--- a/plugins/fl_navigation/example/lib/main.dart
+++ b/plugins/fl_navigation/example/lib/main.dart
@@ -49,12 +49,12 @@ class DemoRoute extends IRoute {
       CustomRouter(
         path: DemoHomeScreen.routeName,
         name: DemoHomeScreen.routeName,
-        builder: (_, __, ___) => const DemoHomeScreen(),
+        builder: (_, _, _) => const DemoHomeScreen(),
       ),
       CustomRouter<DemoArgs>(
         path: DemoDetailsScreen.routeName,
         name: DemoDetailsScreen.routeName,
-        builder: (_, __, extra) {
+        builder: (_, _, extra) {
           return DemoDetailsScreen(
             args: extra as DemoArgs? ?? DemoArgs.empty(),
           );
@@ -64,7 +64,7 @@ class DemoRoute extends IRoute {
       CustomRouter<DemoArgs>(
         path: DemoReplacementScreen.routeName,
         name: DemoReplacementScreen.routeName,
-        builder: (_, __, extra) {
+        builder: (_, _, extra) {
           return DemoReplacementScreen(
             args: extra as DemoArgs? ?? DemoArgs.empty(),
           );
@@ -74,7 +74,7 @@ class DemoRoute extends IRoute {
       CustomRouter<DemoArgs>(
         path: DemoResetScreen.routeName,
         name: DemoResetScreen.routeName,
-        builder: (_, __, extra) {
+        builder: (_, _, extra) {
           return DemoResetScreen(args: extra as DemoArgs? ?? DemoArgs.empty());
         },
         extraFromUrlQueries: DemoArgs.fromQuery,
@@ -90,17 +90,17 @@ class InterceptorDemoRoute extends IRoute {
       CustomRouter(
         path: InterceptorDemoScreen.routeName,
         name: InterceptorDemoScreen.routeName,
-        builder: (_, __, ___) => const InterceptorDemoScreen(),
+        builder: (_, _, _) => const InterceptorDemoScreen(),
       ),
       CustomRouter(
         path: InterceptorAllowedScreen.routeName,
         name: InterceptorAllowedScreen.routeName,
-        builder: (_, __, ___) => const InterceptorAllowedScreen(),
+        builder: (_, _, _) => const InterceptorAllowedScreen(),
       ),
       CustomRouter(
         path: InterceptorFilteredScreen.routeName,
         name: InterceptorFilteredScreen.routeName,
-        builder: (_, __, ___) => const InterceptorFilteredScreen(),
+        builder: (_, _, _) => const InterceptorFilteredScreen(),
       ),
     ];
   }
@@ -113,7 +113,7 @@ class SkippedDemoRoute extends IRoute {
       CustomRouter(
         path: SkippedProviderScreen.routeName,
         name: SkippedProviderScreen.routeName,
-        builder: (_, __, ___) => const SkippedProviderScreen(),
+        builder: (_, _, _) => const SkippedProviderScreen(),
       ),
     ];
   }

--- a/plugins/fl_navigation/example/pubspec.lock
+++ b/plugins/fl_navigation/example/pubspec.lock
@@ -334,14 +334,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   phone_numbers_parser:
     dependency: transitive
     description:

--- a/plugins/fl_navigation/example/pubspec.lock
+++ b/plugins/fl_navigation/example/pubspec.lock
@@ -176,10 +176,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "6.0.0"
   flutter_multi_formatter:
     dependency: transitive
     description:
@@ -266,10 +266,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "6.1.0"
   logger:
     dependency: transitive
     description:

--- a/plugins/fl_navigation/example/pubspec.yaml
+++ b/plugins/fl_navigation/example/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^6.0.0
 
 flutter:
   uses-material-design: true

--- a/plugins/fl_navigation/lib/fl_navigation.dart
+++ b/plugins/fl_navigation/lib/fl_navigation.dart
@@ -1,4 +1,4 @@
-library fl_navigation;
+library;
 
 export 'package:go_router/go_router.dart';
 

--- a/plugins/fl_navigation/pubspec.lock
+++ b/plugins/fl_navigation/pubspec.lock
@@ -161,10 +161,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "6.0.0"
   flutter_multi_formatter:
     dependency: transitive
     description:
@@ -251,10 +251,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "6.1.0"
   logger:
     dependency: transitive
     description:
@@ -319,14 +319,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  pedantic:
-    dependency: "direct main"
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   phone_numbers_parser:
     dependency: transitive
     description:

--- a/plugins/fl_navigation/pubspec.yaml
+++ b/plugins/fl_navigation/pubspec.yaml
@@ -19,14 +19,13 @@ dependencies:
   build: ^4.0.0
   glob: ^2.1.3
   path: ^1.8.2
-  pedantic: ^1.11.1
   yaml: ^3.1.1
   go_router: ^16.2.4
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/plugins/fl_navigation/test/fl_navigation_test.dart
+++ b/plugins/fl_navigation/test/fl_navigation_test.dart
@@ -1,7 +1,8 @@
+import 'dart:async';
+
 import 'package:fl_navigation/fl_navigation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pedantic/pedantic.dart';
 
 void main() {
   group('withQueryParameters', () {
@@ -204,7 +205,7 @@ void main() {
               ),
             );
           }),
-          _TestRouteProviderInterceptor((_, __) {
+          _TestRouteProviderInterceptor((_, _) {
             fail('Resolved route providers must stop the chain.');
           }),
         ],
@@ -255,7 +256,7 @@ void main() {
     test('builds extra from direct value, map extra, and query params', () {
       final router = CustomRouter<_RouteArgs>(
         path: '/sample',
-        builder: (_, __, ___) => const SizedBox(),
+        builder: (_, _, _) => const SizedBox(),
         extraFromUrlQueries: (queryParameters) {
           return _RouteArgs(queryParameters['value'] as String?);
         },
@@ -282,15 +283,15 @@ void main() {
         path: '/parent',
         name: 'parent',
         parentNavigatorKey: navigatorKey,
-        builder: (_, __, ___) => const SizedBox(),
-        pageBuilder: (_, __, ___) {
+        builder: (_, _, _) => const SizedBox(),
+        pageBuilder: (_, _, _) {
           return const MaterialPage<void>(child: Text('Parent'));
         },
-        redirect: (_, __) => null,
+        redirect: (_, _) => null,
         routes: [
           CustomRouter(
             path: 'child',
-            builder: (_, __, ___) => const SizedBox(),
+            builder: (_, _, _) => const SizedBox(),
           ),
         ],
       );
@@ -312,15 +313,15 @@ void main() {
         path: '/parent',
         name: 'parent',
         parentNavigatorKey: navigatorKey,
-        builder: (_, __, ___) => const SizedBox(),
+        builder: (_, _, _) => const SizedBox(),
         routes: [
           CustomRouter(
             path: 'first',
-            builder: (_, __, ___) => const SizedBox(),
+            builder: (_, _, _) => const SizedBox(),
           ),
           CustomRouter(
             path: 'second',
-            builder: (_, __, ___) => const SizedBox(),
+            builder: (_, _, _) => const SizedBox(),
           ),
         ],
       );
@@ -517,7 +518,7 @@ GoRoute _textRoute(String path, String text, {String? name}) {
 CustomRouter _customTextRouter(String path, String text) {
   return CustomRouter(
     path: path,
-    builder: (_, __, ___) => Material(child: Text(text)),
+    builder: (_, _, _) => Material(child: Text(text)),
   );
 }
 

--- a/plugins/fl_theme/analysis_options.yaml
+++ b/plugins/fl_theme/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   language:

--- a/plugins/fl_theme/example/pubspec.lock
+++ b/plugins/fl_theme/example/pubspec.lock
@@ -168,10 +168,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "6.0.0"
   flutter_multi_formatter:
     dependency: transitive
     description:
@@ -253,10 +253,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "6.1.0"
   logger:
     dependency: transitive
     description:

--- a/plugins/fl_theme/example/pubspec.lock
+++ b/plugins/fl_theme/example/pubspec.lock
@@ -305,14 +305,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   phone_numbers_parser:
     dependency: transitive
     description:

--- a/plugins/fl_theme/example/pubspec.yaml
+++ b/plugins/fl_theme/example/pubspec.yaml
@@ -40,7 +40,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/plugins/fl_theme/lib/fl_theme.dart
+++ b/plugins/fl_theme/lib/fl_theme.dart
@@ -1,4 +1,4 @@
-library fl_theme;
+library;
 
 export 'src/app_component_theme.dart';
 export 'src/app_decoration_theme.dart';

--- a/plugins/fl_theme/pubspec.lock
+++ b/plugins/fl_theme/pubspec.lock
@@ -145,10 +145,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "6.0.0"
   flutter_multi_formatter:
     dependency: transitive
     description:
@@ -214,10 +214,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "6.1.0"
   logger:
     dependency: transitive
     description:
@@ -266,14 +266,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  pedantic:
-    dependency: "direct main"
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   phone_numbers_parser:
     dependency: transitive
     description:

--- a/plugins/fl_theme/pubspec.yaml
+++ b/plugins/fl_theme/pubspec.yaml
@@ -17,12 +17,11 @@ dependencies:
     path: ../fl_utils
 
   flex_color_scheme: ^8.4.0
-  pedantic: ^1.11.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/plugins/fl_ui/analysis_options.yaml
+++ b/plugins/fl_ui/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   language:
@@ -6,10 +6,15 @@ analyzer:
   errors:
     # allow having TODOs in the code
     todo: ignore
+    # Widget State subclasses intentionally expose private types via builder APIs.
+    library_private_types_in_public_api: ignore
+    # Intentional `_x = x ?? default` locals shadow-guard constructor fields of the same name.
+    no_leading_underscores_for_local_identifiers: ignore
   exclude:
     # exclude files
     - .dart_tool/**
     - build/**
+    - lib/generated
     - lib/src/generated_plugin_registrant.dart
     - lib/src/di/di.config.dart
     - "**.g.dart"

--- a/plugins/fl_ui/example/pubspec.lock
+++ b/plugins/fl_ui/example/pubspec.lock
@@ -445,10 +445,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "6.0.0"
   flutter_localizations:
     dependency: transitive
     description: flutter
@@ -708,10 +708,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "6.1.0"
   logger:
     dependency: transitive
     description:

--- a/plugins/fl_ui/example/pubspec.lock
+++ b/plugins/fl_ui/example/pubspec.lock
@@ -864,14 +864,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   petitparser:
     dependency: transitive
     description:

--- a/plugins/fl_ui/example/pubspec.yaml
+++ b/plugins/fl_ui/example/pubspec.yaml
@@ -39,7 +39,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/plugins/fl_ui/lib/fl_ui.dart
+++ b/plugins/fl_ui/lib/fl_ui.dart
@@ -1,4 +1,4 @@
-library fl_ui;
+library;
 
 export 'src/after_layout.dart';
 export 'src/animated_dropdown_icon.dart';

--- a/plugins/fl_ui/lib/src/availability_widget.dart
+++ b/plugins/fl_ui/lib/src/availability_widget.dart
@@ -32,14 +32,14 @@ class AvailabilityWidget extends StatefulWidget {
   final Curve animationCurve;
 
   const AvailabilityWidget({
-    Key? key,
+    super.key,
     required this.child,
     this.enable = true,
     this.absorbingWhenDisabled = true,
     this.greyOpacity = 0.85,
     this.animationDuration,
     this.animationCurve = Curves.easeInOut,
-  }) : super(key: key);
+  });
 
   /// Factory constructor for animated availability widget.
   /// Provides smooth transitions between enabled/disabled states.

--- a/plugins/fl_ui/lib/src/badge_box.dart
+++ b/plugins/fl_ui/lib/src/badge_box.dart
@@ -11,14 +11,14 @@ class BadgeBox extends StatelessWidget {
   final int maxCount;
 
   const BadgeBox({
-    Key? key,
+    super.key,
     required this.count,
     required this.child,
     this.countTextColor,
     this.backgroundColor,
     this.badgePosition,
     this.maxCount = 99,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/plugins/fl_ui/lib/src/banner_widget.dart
+++ b/plugins/fl_ui/lib/src/banner_widget.dart
@@ -20,7 +20,7 @@ class BannerWidget<T> extends StatefulWidget {
   final BoxFit fit;
 
   const BannerWidget({
-    Key? key,
+    super.key,
     this.banners,
     this.onTap,
     required this.getImageUrl,
@@ -33,7 +33,7 @@ class BannerWidget<T> extends StatefulWidget {
     this.placeHolder,
     this.autoPlayInterval = const Duration(seconds: 5),
     this.fit = BoxFit.cover,
-  }) : super(key: key);
+  });
 
   @override
   _BannerWidgetState createState() => _BannerWidgetState<T>();
@@ -141,14 +141,14 @@ class BannerItem<T> extends StatelessWidget {
   final BoxFit fit;
 
   const BannerItem({
-    Key? key,
+    super.key,
     this.item,
     this.onTap,
     this.url,
     this.placeHolder,
     this.borderRadius = BorderRadius.zero,
     this.fit = BoxFit.cover,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/plugins/fl_ui/lib/src/box_color.dart
+++ b/plugins/fl_ui/lib/src/box_color.dart
@@ -14,7 +14,7 @@ class BoxColor extends StatelessWidget {
   final List<BoxShadow>? boxShadow;
 
   const BoxColor({
-    Key? key,
+    super.key,
     this.color,
     this.borderRadius,
     this.child,
@@ -25,7 +25,7 @@ class BoxColor extends StatelessWidget {
     this.alignment,
     this.boxShape = BoxShape.rectangle,
     this.boxShadow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -62,7 +62,7 @@ class HighlightBoxColor extends StatelessWidget {
   final List<BoxShadow>? boxShadow;
 
   const HighlightBoxColor({
-    Key? key,
+    super.key,
     this.child,
     this.margin,
     this.padding = const EdgeInsets.all(8),
@@ -74,7 +74,7 @@ class HighlightBoxColor extends StatelessWidget {
     this.borderRadius,
     this.borderWidth,
     this.boxShadow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -114,7 +114,7 @@ class ChipItem extends StatelessWidget {
   final Color? selectedColor;
 
   const ChipItem({
-    Key? key,
+    super.key,
     required this.selected,
     required this.text,
     required this.textTheme,
@@ -124,7 +124,7 @@ class ChipItem extends StatelessWidget {
     this.selectedBGColor,
     this.color,
     this.selectedColor,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/plugins/fl_ui/lib/src/check_box.dart
+++ b/plugins/fl_ui/lib/src/check_box.dart
@@ -14,7 +14,7 @@ class CheckboxWithTitle extends StatefulWidget {
   final double? space;
 
   const CheckboxWithTitle({
-    Key? key,
+    super.key,
     required this.title,
     this.size = 24,
     this.style,
@@ -23,7 +23,7 @@ class CheckboxWithTitle extends StatefulWidget {
     this.enable = true,
     this.borderColor,
     this.space,
-  }) : super(key: key);
+  });
 
   @override
   State<CheckboxWithTitle> createState() => _CheckboxWithTitleState();
@@ -117,7 +117,7 @@ class CheckBoxGroup<T> extends StatefulWidget {
   final TextStyle? labelStyle;
 
   const CheckBoxGroup({
-    Key? key,
+    super.key,
     required this.items,
     required this.getLabel,
     required this.onSelectedChanged,
@@ -127,7 +127,7 @@ class CheckBoxGroup<T> extends StatefulWidget {
     this.compare,
     this.labelStyle,
     this.disableItems = const [],
-  }) : super(key: key);
+  });
 
   @override
   _CheckBoxGroupState createState() => _CheckBoxGroupState<T>();
@@ -183,12 +183,12 @@ class _CheckBoxGroupState<T> extends State<CheckBoxGroup<T>> {
   }
 
   void selectItem(bool? selected, T e) {
-    final equal = (T a, T b) {
+    bool equal(T a, T b) {
       if (widget.compare != null) {
         return widget.compare!.call(a, b);
       }
       return a == b;
-    };
+    }
 
     if (selected != true) {
       // case deselected
@@ -199,8 +199,9 @@ class _CheckBoxGroupState<T> extends State<CheckBoxGroup<T>> {
       }
     } else {
       if (!seleted.any((s) => equal(e, s))) {
-        if (widget.onlyItem != null) {
-          if (equal(e, widget.onlyItem!)) {
+        final onlyItem = widget.onlyItem;
+        if (onlyItem != null) {
+          if (equal(e, onlyItem)) {
             setState(() {
               seleted
                 ..clear()
@@ -208,7 +209,7 @@ class _CheckBoxGroupState<T> extends State<CheckBoxGroup<T>> {
             });
           } else {
             final items = [
-              ...seleted.where((e) => !equal(e, widget.onlyItem!)),
+              ...seleted.where((e) => !equal(e, onlyItem)),
             ];
             setState(() {
               seleted

--- a/plugins/fl_ui/lib/src/custom_stepper.dart
+++ b/plugins/fl_ui/lib/src/custom_stepper.dart
@@ -61,7 +61,7 @@ class StepData {
 class VerticalStepper extends StatelessWidget {
   final List<StepData> steps;
 
-  const VerticalStepper({Key? key, required this.steps}) : super(key: key);
+  const VerticalStepper({super.key, required this.steps});
 
   @override
   Widget build(BuildContext context) {
@@ -88,12 +88,12 @@ class AnimatedSlideBox extends StatefulWidget {
   final Duration duration;
 
   const AnimatedSlideBox({
-    Key? key,
+    super.key,
     this.child,
     this.begin = const Offset(0.0, -0.5),
     this.end = Offset.zero,
     this.duration = const Duration(seconds: 1),
-  }) : super(key: key);
+  });
 
   @override
   State<AnimatedSlideBox> createState() => _AnimatedSlideBoxState();

--- a/plugins/fl_ui/lib/src/custom_tabbar.dart
+++ b/plugins/fl_ui/lib/src/custom_tabbar.dart
@@ -3,13 +3,13 @@ import 'package:flutter/material.dart';
 
 class CustomTabbar extends StatefulWidget {
   const CustomTabbar({
-    Key? key,
+    super.key,
     required this.titles,
     required this.onTap,
     this.selectedIdx = 0,
     this.borderRadius,
     this.bgColor,
-  }) : super(key: key);
+  });
 
   final List<String> titles;
   final int selectedIdx;
@@ -86,12 +86,12 @@ class TabItem extends StatelessWidget {
   final double? borderRadius;
 
   const TabItem({
-    Key? key,
+    super.key,
     required this.title,
     required this.selected,
     required this.onTap,
     this.borderRadius,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/plugins/fl_ui/lib/src/error_box.dart
+++ b/plugins/fl_ui/lib/src/error_box.dart
@@ -16,7 +16,7 @@ class ErrorBox extends StatefulWidget {
   final String? validation;
 
   const ErrorBox({
-    Key? key,
+    super.key,
     required this.child,
     this.controller,
     this.errorStyle,
@@ -25,7 +25,7 @@ class ErrorBox extends StatefulWidget {
     this.errorBoxPadding,
     this.errorTextPadding = const EdgeInsets.only(top: 8),
     this.validation,
-  }) : super(key: key);
+  });
 
   @override
   State<ErrorBox> createState() => _ErrorBoxState();

--- a/plugins/fl_ui/lib/src/expandable_widget.dart
+++ b/plugins/fl_ui/lib/src/expandable_widget.dart
@@ -13,7 +13,7 @@ class ExpandableWidget extends StatefulWidget {
   final bool toggleCtrWhenTapHeader;
 
   const ExpandableWidget({
-    Key? key,
+    super.key,
     this.controller,
     required this.header,
     required this.body,
@@ -21,7 +21,7 @@ class ExpandableWidget extends StatefulWidget {
     this.divider,
     this.toggleCtrWhenTapHeader = true,
     this.isExpanded,
-  }) : super(key: key);
+  });
 
   @override
   _ExpandableWidgetState createState() => _ExpandableWidgetState();

--- a/plugins/fl_ui/lib/src/hidable_button_nav.dart
+++ b/plugins/fl_ui/lib/src/hidable_button_nav.dart
@@ -29,7 +29,7 @@ class HidableBottomScrollListener extends ChangeNotifier {
   void addController(ScrollController controller) {
     if (!_controllers.contains(controller)) {
       _controllers.add(controller);
-      final ls = () => listenOnCtrl(controller);
+      void ls() => listenOnCtrl(controller);
       controller.addListener(ls);
       _listeners.add(ls);
     }

--- a/plugins/fl_ui/lib/src/info_item.dart
+++ b/plugins/fl_ui/lib/src/info_item.dart
@@ -31,7 +31,7 @@ class InfoItem extends StatelessWidget {
   final bool? required;
 
   const InfoItem({
-    Key? key,
+    super.key,
     required this.title,
     this.value,
     this.color,
@@ -54,8 +54,7 @@ class InfoItem extends StatelessWidget {
        assert(
          value == null || value is String || value is Widget,
          '$value [String, Widget] is supported',
-       ),
-       super(key: key);
+       );
 
   @override
   Widget build(BuildContext context) {

--- a/plugins/fl_ui/lib/src/keep_alive_widget.dart
+++ b/plugins/fl_ui/lib/src/keep_alive_widget.dart
@@ -2,10 +2,10 @@ import 'package:flutter/cupertino.dart';
 
 class KeepAliveWidget extends StatefulWidget {
   const KeepAliveWidget({
-    Key? key,
+    super.key,
     required this.child,
     this.wantKeepAlive = true,
-  }) : super(key: key);
+  });
 
   final Widget child;
   final bool wantKeepAlive;

--- a/plugins/fl_ui/lib/src/loading.dart
+++ b/plugins/fl_ui/lib/src/loading.dart
@@ -5,8 +5,7 @@ class Loading extends StatelessWidget {
   final Brightness? brightness;
   final double radius;
 
-  const Loading({Key? key, this.brightness, this.radius = 15})
-    : super(key: key);
+  const Loading({super.key, this.brightness, this.radius = 15});
 
   @override
   Widget build(BuildContext context) {

--- a/plugins/fl_ui/lib/src/measure_size.dart
+++ b/plugins/fl_ui/lib/src/measure_size.dart
@@ -28,8 +28,8 @@ class MeasureSizeRenderObject extends RenderProxyBox {
 class MeasureSize extends SingleChildRenderObjectWidget {
   final OnWidgetSizeChange onChange;
 
-  const MeasureSize({Key? key, required this.onChange, required Widget child})
-    : super(key: key, child: child);
+  const MeasureSize({super.key, required this.onChange, required Widget child})
+    : super(child: child);
 
   @override
   RenderObject createRenderObject(BuildContext context) {

--- a/plugins/fl_ui/lib/src/menu_item_widget.dart
+++ b/plugins/fl_ui/lib/src/menu_item_widget.dart
@@ -4,7 +4,7 @@ import '../fl_ui.dart';
 
 class MenuItemWidget extends StatelessWidget {
   const MenuItemWidget({
-    Key? key,
+    super.key,
     required this.title,
     this.icon,
     this.onTap,
@@ -19,8 +19,7 @@ class MenuItemWidget extends StatelessWidget {
   }) : assert(
          title is String || title is Widget,
          '$title [String, Widget] is supported',
-       ),
-       super(key: key);
+       );
 
   /// [String, Widget] is supported
   final dynamic title;
@@ -105,7 +104,7 @@ class MenuItemWidget extends StatelessWidget {
                       padding: const EdgeInsets.only(right: 8),
                       child: description!,
                     ),
-                  if (tailIcon != null) tailIcon!,
+                  ?tailIcon,
                   if (onTap != null && tailIcon == null)
                     const Icon(
                       Icons.chevron_right_rounded,

--- a/plugins/fl_ui/lib/src/page_indicator.dart
+++ b/plugins/fl_ui/lib/src/page_indicator.dart
@@ -23,7 +23,7 @@ class PageIndicatorWidget extends StatefulWidget {
   final int initialPage;
 
   const PageIndicatorWidget({
-    Key? key,
+    super.key,
     required this.countItem,
     this.controller,
     this.isShowButtonAction = true,
@@ -39,7 +39,7 @@ class PageIndicatorWidget extends StatefulWidget {
     this.size = const Size(8, 8),
     this.spacing = const EdgeInsets.all(6),
     this.initialPage = 0,
-  }) : super(key: key);
+  });
 
   @override
   State<PageIndicatorWidget> createState() => _PageIndicatorWidgetState();

--- a/plugins/fl_ui/lib/src/radio_button.dart
+++ b/plugins/fl_ui/lib/src/radio_button.dart
@@ -15,7 +15,7 @@ class RadioButtonWithTitle<T> extends StatelessWidget {
   final EdgeInsets padding;
 
   const RadioButtonWithTitle({
-    Key? key,
+    super.key,
     required this.title,
     required this.value,
     required this.groupValue,
@@ -27,8 +27,7 @@ class RadioButtonWithTitle<T> extends StatelessWidget {
   }) : assert(
          title is String || title is Widget,
          '$title [String, Widget] is supported',
-       ),
-       super(key: key);
+       );
 
   @override
   Widget build(BuildContext context) {
@@ -86,13 +85,13 @@ class FlRadioGroup<T> extends StatefulWidget {
   final Axis axis;
 
   const FlRadioGroup({
-    Key? key,
+    super.key,
     required this.items,
     required this.onSelected,
     required this.getLabel,
     this.selectedItem,
     this.axis = Axis.vertical,
-  }) : super(key: key);
+  });
 
   @override
   _FlRadioGroupState createState() => _FlRadioGroupState<T>();
@@ -124,8 +123,8 @@ class _FlRadioGroupState<T> extends State<FlRadioGroup<T>> {
             onChanged: (T? value) {
               setState(() {
                 seleted = value;
-                if (seleted != null) {
-                  widget.onSelected(seleted!);
+                if (value != null) {
+                  widget.onSelected(value);
                 }
               });
             },

--- a/plugins/fl_ui/lib/src/receipt_shape.dart
+++ b/plugins/fl_ui/lib/src/receipt_shape.dart
@@ -6,7 +6,10 @@ class ReceiptShapeBorder extends ShapeBorder {
   final Color borderColor;
   final double borderWidth;
 
-  ReceiptShapeBorder({required this.borderColor, required this.borderWidth});
+  const ReceiptShapeBorder({
+    required this.borderColor,
+    required this.borderWidth,
+  });
 
   Path _getClip(Size size) {
     var pattern = 9.0;

--- a/plugins/fl_ui/lib/src/separator.dart
+++ b/plugins/fl_ui/lib/src/separator.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 
 class Separator extends StatelessWidget {
   const Separator({
-    Key? key,
+    super.key,
     this.dashHeight = 1,
     this.dashWidth = 3,
     this.color = Colors.black,
-  }) : super(key: key);
+  });
   final double dashHeight;
   final double dashWidth;
   final Color color;

--- a/plugins/fl_ui/lib/src/shimmer_wrapper.dart
+++ b/plugins/fl_ui/lib/src/shimmer_wrapper.dart
@@ -7,11 +7,11 @@ class ShimmerWrapper extends StatelessWidget {
   final Widget child;
 
   const ShimmerWrapper({
-    Key? key,
+    super.key,
     required this.isLoading,
     required this.child,
     this.baseColor = Colors.white,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -80,14 +80,14 @@ class Shimmer extends StatefulWidget {
   final bool enabled;
 
   const Shimmer({
-    Key? key,
+    super.key,
     required this.child,
     required this.gradient,
     this.direction = ShimmerDirection.ltr,
     this.period = const Duration(milliseconds: 1500),
     this.loop = 0,
     this.enabled = true,
-  }) : super(key: key);
+  });
 
   ///
   /// A convenient constructor provides an easy and convenient way to create a
@@ -95,7 +95,7 @@ class Shimmer extends StatefulWidget {
   /// `highlightColor`.
   ///
   Shimmer.fromColors({
-    Key? key,
+    super.key,
     required this.child,
     required Color baseColor,
     required Color highlightColor,
@@ -114,8 +114,7 @@ class Shimmer extends StatefulWidget {
            baseColor,
          ],
          stops: const <double>[0.0, 0.35, 0.5, 0.65, 1.0],
-       ),
-       super(key: key);
+       );
 
   @override
   _ShimmerState createState() => _ShimmerState();
@@ -197,11 +196,11 @@ class _Shimmer extends SingleChildRenderObjectWidget {
   final Gradient gradient;
 
   const _Shimmer({
-    Widget? child,
+    super.child,
     required this.percent,
     required this.direction,
     required this.gradient,
-  }) : super(child: child);
+  });
 
   @override
   _ShimmerFilter createRenderObject(BuildContext context) {

--- a/plugins/fl_ui/lib/src/story_book_widget.dart
+++ b/plugins/fl_ui/lib/src/story_book_widget.dart
@@ -4,6 +4,7 @@ import 'box_color.dart';
 
 class StoryWidgetBox<T> extends StatefulWidget {
   const StoryWidgetBox({
+    super.key,
     required this.builder,
     this.title = '',
     this.description = '',

--- a/plugins/fl_ui/lib/src/switching_layout.dart
+++ b/plugins/fl_ui/lib/src/switching_layout.dart
@@ -16,13 +16,13 @@ class LayoutSwitching extends StatefulWidget {
   final SwitchingAnimation direction;
 
   const LayoutSwitching({
-    Key? key,
+    super.key,
     required this.first,
     required this.second,
     this.isFirstLayout = true,
     this.duration = const Duration(milliseconds: 250),
     this.direction = SwitchingAnimation.swipeRTL,
-  }) : super(key: key);
+  });
 
   @override
   State<LayoutSwitching> createState() => _LayoutSwitchingState();

--- a/plugins/fl_ui/lib/src/tab_page_widget.dart
+++ b/plugins/fl_ui/lib/src/tab_page_widget.dart
@@ -4,12 +4,12 @@ import 'package:flutter/material.dart';
 
 class TabBox extends StatelessWidget {
   const TabBox({
-    Key? key,
+    super.key,
     this.child,
     this.tabBarHeight,
     this.tabBarDecoration,
     this.tabBarMargin,
-  }) : super(key: key);
+  });
 
   final Widget? child;
   final double? tabBarHeight;
@@ -69,7 +69,7 @@ class TabPageWidget extends StatefulWidget {
   final bool? useMaterial3;
 
   const TabPageWidget({
-    Key? key,
+    super.key,
     required this.tabBuilder,
     required this.pageBuilder,
     required this.length,
@@ -91,7 +91,7 @@ class TabPageWidget extends StatefulWidget {
     this.tabBarPadding,
     this.allowAnimateToPage = true,
     this.useMaterial3,
-  }) : super(key: key);
+  });
 
   @override
   State<TabPageWidget> createState() => _TabPageWidgetState();

--- a/plugins/fl_ui/lib/src/text_scale_fixed.dart
+++ b/plugins/fl_ui/lib/src/text_scale_fixed.dart
@@ -4,7 +4,11 @@ class TextScaleFixed extends StatelessWidget {
   final double scaleFixedFactor;
   final Widget child;
 
-  TextScaleFixed({this.scaleFixedFactor = 1, required this.child});
+  const TextScaleFixed({
+    super.key,
+    this.scaleFixedFactor = 1,
+    required this.child,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/plugins/fl_ui/lib/src/view_more.dart
+++ b/plugins/fl_ui/lib/src/view_more.dart
@@ -11,13 +11,13 @@ class ViewMoreWidget extends StatefulWidget {
   final double minHeight;
 
   const ViewMoreWidget({
-    Key? key,
+    super.key,
     required this.child,
     this.expand = false,
     required this.viewMore,
     required this.seeLess,
     this.minHeight = 200,
-  }) : super(key: key);
+  });
 
   @override
   State<ViewMoreWidget> createState() => _ViewMoreWidgetState();

--- a/plugins/fl_ui/pubspec.lock
+++ b/plugins/fl_ui/pubspec.lock
@@ -446,10 +446,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "6.0.0"
   flutter_localizations:
     dependency: transitive
     description: flutter
@@ -709,10 +709,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "6.1.0"
   logger:
     dependency: transitive
     description:
@@ -872,14 +872,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
-  pedantic:
-    dependency: "direct main"
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   petitparser:
     dependency: transitive
     description:

--- a/plugins/fl_ui/pubspec.yaml
+++ b/plugins/fl_ui/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-  pedantic: ^1.11.1
   uuid: 
 
   carousel_slider: ^5.0.0
@@ -32,7 +31,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^6.0.0
   module_generator:
     path: ../../tools/module_generator
 

--- a/plugins/fl_utils/analysis_options.yaml
+++ b/plugins/fl_utils/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   language:
@@ -6,6 +6,8 @@ analyzer:
   errors:
     # allow having TODOs in the code
     todo: ignore
+    # `_x = x ?? default` shadow-guard locals are an intentional convention.
+    no_leading_underscores_for_local_identifiers: ignore
   exclude:
     # exclude files
     - .dart_tool/**

--- a/plugins/fl_utils/example/pubspec.lock
+++ b/plugins/fl_utils/example/pubspec.lock
@@ -137,10 +137,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "6.0.0"
   flutter_multi_formatter:
     dependency: transitive
     description:
@@ -206,10 +206,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "6.1.0"
   logger:
     dependency: transitive
     description:

--- a/plugins/fl_utils/example/pubspec.lock
+++ b/plugins/fl_utils/example/pubspec.lock
@@ -258,14 +258,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   phone_numbers_parser:
     dependency: transitive
     description:

--- a/plugins/fl_utils/example/pubspec.yaml
+++ b/plugins/fl_utils/example/pubspec.yaml
@@ -39,7 +39,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/plugins/fl_utils/lib/fl_utils.dart
+++ b/plugins/fl_utils/lib/fl_utils.dart
@@ -1,4 +1,4 @@
-library fl_utils;
+library;
 
 export 'src/common_function.dart';
 export 'src/condition_builder.dart';

--- a/plugins/fl_utils/lib/src/condition_builder.dart
+++ b/plugins/fl_utils/lib/src/condition_builder.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: lines_longer_than_80_chars
 /// Represents a condition and its associated value.
-
 class Conditional<T> {
   /// The function that determines if the condition is met.
   final bool Function() condition;

--- a/plugins/fl_utils/lib/src/extensions.dart
+++ b/plugins/fl_utils/lib/src/extensions.dart
@@ -5,7 +5,7 @@ import 'number_format_utils.dart';
 import 'phone_number_utils.dart';
 
 extension ExtendedIterable<E> on Iterable<E> {
-  /// Like Iterable<T>.map but callback have index as second argument
+  /// Like `Iterable<T>.map` but callback have index as second argument
   Iterable<T> mapIndex<T>(T Function(E e, int i) f) {
     var i = 0;
     return map((e) => f(e, i++));
@@ -523,7 +523,7 @@ extension WeightExt on int {
   String formatNumber({String prefix = ''}) {
     const pattern = r'(\d{1,3})(?=(\d{3})+(?!\d))';
     final regExp = RegExp(pattern);
-    final mathFunc = (Match match) => '${match[1]},';
+    String mathFunc(Match match) => '${match[1]},';
     return '${toString().replaceAllMapped(regExp, mathFunc)}$prefix';
   }
 }

--- a/plugins/fl_utils/lib/src/qr_payment.dart
+++ b/plugins/fl_utils/lib/src/qr_payment.dart
@@ -12,7 +12,7 @@ class QRPaymentUtil {
     String? note,
   }) {
     final consumerAccountInformation = [
-      '${guid.formatTLV('00')}',
+      guid.formatTLV('00'),
       [
         bankBin.formatTLV('00'),
         bankAcount.formatTLV('01'),

--- a/plugins/fl_utils/pubspec.lock
+++ b/plugins/fl_utils/pubspec.lock
@@ -122,10 +122,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "6.0.0"
   flutter_multi_formatter:
     dependency: "direct main"
     description:
@@ -140,7 +140,7 @@ packages:
     source: sdk
     version: "0.0.0"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
@@ -191,10 +191,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "6.1.0"
   logger:
     dependency: "direct main"
     description:
@@ -243,14 +243,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  pedantic:
-    dependency: "direct main"
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   phone_numbers_parser:
     dependency: "direct main"
     description:

--- a/plugins/fl_utils/pubspec.yaml
+++ b/plugins/fl_utils/pubspec.yaml
@@ -16,15 +16,16 @@ dependencies:
   date_format: ^2.0.2
   timeago: ^3.1.0
   encrypt: ^5.0.1
-  pedantic: ^1.11.1
   jwt_decode: ^0.3.1
   phone_numbers_parser: ^9.0.3
   number_text_input_formatter: ^1.0.0+8
 
+  intl:
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/tools/module_generator/analysis_options.yaml
+++ b/tools/module_generator/analysis_options.yaml
@@ -7,7 +7,7 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   exclude:
@@ -20,6 +20,8 @@ analyzer:
     todo: ignore
     missing_return: error
     dead_code: info
+    # `_x = x ?? default` shadow-guard locals are an intentional convention.
+    no_leading_underscores_for_local_identifiers: ignore
 
 formatter:
   trailing_commas: preserve

--- a/tools/module_generator/lib/common/common_function.dart
+++ b/tools/module_generator/lib/common/common_function.dart
@@ -35,7 +35,7 @@ extension StringExtension on String {
 }
 
 extension ExtendedIterable<E> on Iterable<E> {
-  /// Like Iterable<T>.map but callback have index as second argument
+  /// Like `Iterable<T>.map` but callback have index as second argument
   Iterable<T> mapIndex<T>(T Function(E e, int i) f) {
     var i = 0;
     return map((e) => f(e, i++));

--- a/tools/module_generator/lib/common/file_helper.dart
+++ b/tools/module_generator/lib/common/file_helper.dart
@@ -91,7 +91,7 @@ class YamlWriter {
       lines.add(
         yaml.contains(' ')
             ? "\"${yaml.replaceAll("\"", "\\\"")}\""
-            : "${yaml.replaceAll("\"", "\\\"")}",
+            : yaml.replaceAll('"', '\\"'),
       );
     } else {
       lines.add(yaml.toString());
@@ -126,7 +126,7 @@ class YamlWriter {
       } else {
         lines.addAll([
           '${_indent(indent)}${key.toString()}:',
-          '${_writeInternal(value, indent: indent + 1)}',
+          _writeInternal(value, indent: indent + 1),
         ]);
       }
     }

--- a/tools/module_generator/lib/generator/create_project.dart
+++ b/tools/module_generator/lib/generator/create_project.dart
@@ -508,9 +508,7 @@ class CreateProjectGenerator {
     final rows = await file
         .openRead()
         .transform(utf8.decoder)
-        .transform(
-          CsvToListConverter(eol: Platform.isMacOS ? '\n' : defaultEol),
-        )
+        .transform(const CsvToListConverter(eol: '\n'))
         .toList();
 
     for (final row in rows) {

--- a/tools/module_generator/lib/generator/generate_export.dart
+++ b/tools/module_generator/lib/generator/generate_export.dart
@@ -114,7 +114,7 @@ Future<void> generateExport({required List<YamlMap> config}) async {
     ]..sort();
 
     contents
-      ..removeWhere((e) => e.contains('''\'${c.fileName}\''''))
+      ..removeWhere((e) => e.contains(''''${c.fileName}\''''))
       ..add('');
 
     await FilesHelper.writeFile(

--- a/tools/module_generator/lib/res/templates/asset/rive_assets.dart
+++ b/tools/module_generator/lib/res/templates/asset/rive_assets.dart
@@ -16,7 +16,7 @@ final riveAssetsArtboardRes =
     '''class ${classNameKey}Artboard {
   ${classNameKey}Artboard();
 
-  final String name = \'$artboardKey\';
+  final String name = '$artboardKey';
 
   final ${classNameKey}Inputs inputs = ${classNameKey}Inputs();
 

--- a/tools/module_generator/pubspec.lock
+++ b/tools/module_generator/pubspec.lock
@@ -110,14 +110,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_lints:
-    dependency: "direct dev"
-    description:
-      name: flutter_lints
-      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -156,7 +148,7 @@ packages:
     source: hosted
     version: "3.0.2"
   lints:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: lints
       sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
@@ -203,14 +195,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  pedantic:
-    dependency: "direct main"
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   pub_semver:
     dependency: transitive
     description:

--- a/tools/module_generator/pubspec.yaml
+++ b/tools/module_generator/pubspec.yaml
@@ -14,12 +14,11 @@ dependencies:
   yaml: ^3.1.1
   csv: ^6.0.0
   path: ^1.8.2
-  pedantic: ^1.11.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^6.0.0
+  lints: ^6.0.0
   analyzer: ^7.0.0
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
## Summary

Replace the discontinued `pedantic` ruleset with `flutter_lints ^6.0.0`, clear the 207 analyzer findings it exposed, and enforce a single `make check` definition-of-done gate locally and in GitHub Actions.

## Changes

- Modernized the lint configuration across the repository; `tools/module_generator` uses `lints/recommended.yaml` because it is a pure Dart package.
- Fixed all 207 analyzer findings without using `dart fix --apply` or broadly reformatting hand-written code.
- Declared dependencies that were previously used only through transitive resolution.
- Added `make check` (`analyze` + `format_check` + `test`) and shared formatting scope for `make format` / `make format_check`.
- Updated `AGENTS.md`, the README, and the pull-request template to use the same hard gate.

## Review fixes

- Test discovery derives from the full 14-package list and safely skips packages without test directories.
- All five analyzed example apps now resolve `flutter_lints ^6.0.0`.
- GitHub Actions runs `make check` for pull requests and pushes to `master`.
- Preserved the prior app runtime resolution: `flutter_svg 2.2.0` and `vector_graphics 1.1.19`.

## Verification

- [x] `make check`
  - 14 packages analyzed
  - Formatting clean
  - All 10 discovered package test suites passed
- [x] Deliberate info-level lint makes the gate fail
- [x] Deliberate formatting violation makes the gate fail and reports the affected files
- [x] No localization, generated-source, route, distribution, or signing changes

## Review notes

- `plugins/fl_ui/lib/src/check_box.dart` and `radio_button.dart` contain the only non-mechanical lint fixes. Their control flow changed to promote nullable values safely; behavior is intended to remain identical.
- Four unused private-widget `key` parameters were removed after `super.key` exposed that no caller supplied them.
- `make format` now excludes `node_modules` and generated outputs, matching `make format_check`.
- `core/lib/di/core_micro.module.dart` remains excluded as generated output and was not hand-edited.
